### PR TITLE
fix: production hardening across 6 areas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,6 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
-
       - name: Lint
         run: make lint
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,11 +35,14 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
 
 FROM alpine:3.21
 
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates && \
+    adduser -D -u 10001 appuser
 
 COPY --from=builder /build/s3-orchestrator /usr/local/bin/
 
-EXPOSE 8080
+USER appuser
+
+EXPOSE 9000
 
 ENTRYPOINT ["s3-orchestrator"]
 CMD ["-config", "/etc/s3-orchestrator/config.yaml"]


### PR DESCRIPTION
- Remove dead golangci-lint v1 install from CI (make lint uses v2 via go run)
- Limit CompleteMultipartUpload XML body to 1MB to prevent memory exhaustion
- Add backend timeouts to rebalancer and replicator S3 operations
- Run container as non-root user (appuser, uid 10001)
- Fix EXPOSE port from 8080 to 9000 to match default config
- Reorder shutdown to drain HTTP before cancelling background tasks