### PR TITLE
fix: table alignment with fixed layout and explicit column widths

### DIFF
--- a/internal/ui/static/style.css
+++ b/internal/ui/static/style.css
@@ -51,35 +51,39 @@ section h2 {
 /* --- Tables --- */
 table {
   width: 100%;
+  table-layout: fixed;
   border-collapse: collapse;
   background: #1e293b;
   border-radius: 0.5rem;
   overflow: hidden;
 }
 
+th, td {
+  padding: 0.6rem 1rem;
+  border-bottom: 1px solid #334155;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 th {
   text-align: left;
-  padding: 0.6rem 1rem;
   font-size: 0.75rem;
   font-weight: 600;
   color: #64748b;
   text-transform: uppercase;
   letter-spacing: 0.05em;
   background: #0f172a;
-  border-bottom: 1px solid #334155;
 }
 
-th.num { text-align: right; }
+td { font-size: 0.85rem; }
 
-td {
-  padding: 0.6rem 1rem;
-  font-size: 0.85rem;
-  border-bottom: 1px solid #334155;
+th.num, td.num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
 }
 
 tr:last-child td { border-bottom: none; }
-
-td.num { text-align: right; font-variant-numeric: tabular-nums; }
 
 td.key {
   word-break: break-all;

--- a/internal/ui/templates/dashboard.html
+++ b/internal/ui/templates/dashboard.html
@@ -28,13 +28,22 @@
   <section>
     <h2>Backends</h2>
     <table>
+      <colgroup>
+        <col style="width:14%">
+        <col style="width:12%">
+        <col style="width:12%">
+        <col style="width:10%">
+        <col style="width:22%">
+        <col style="width:10%">
+        <col style="width:10%">
+      </colgroup>
       <thead>
         <tr>
           <th>Name</th>
           <th class="num">Quota Used</th>
           <th class="num">Quota Limit</th>
           <th class="num">Usage</th>
-          <th style="width:20%"></th>
+          <th></th>
           <th class="num">Objects</th>
           <th class="num">Multipart</th>
         </tr>
@@ -48,9 +57,9 @@
             <td>{{.}}</td>
             <td class="num">{{formatBytes $stat.BytesUsed}}</td>
             <td class="num">
-              {{if eq $stat.BytesLimit 0}}unlimited
-              {{else}}{{formatBytes $stat.BytesLimit}}
-              {{end}}
+              {{- if eq $stat.BytesLimit 0}}unlimited
+              {{- else}}{{formatBytes $stat.BytesLimit}}
+              {{- end -}}
             </td>
             <td class="num">{{pct $stat.BytesUsed $stat.BytesLimit}}</td>
             <td>
@@ -72,6 +81,15 @@
   <section>
     <h2>Monthly Usage ({{.Data.UsagePeriod}})</h2>
     <table>
+      <colgroup>
+        <col style="width:14%">
+        <col style="width:14%">
+        <col style="width:14%">
+        <col style="width:14%">
+        <col style="width:14%">
+        <col style="width:14%">
+        <col style="width:14%">
+      </colgroup>
       <thead>
         <tr>
           <th>Backend</th>
@@ -91,21 +109,21 @@
             <td>{{.}}</td>
             <td class="num">{{formatNumber $usage.ApiRequests}}</td>
             <td class="num">
-              {{if eq $limits.ApiRequestLimit 0}}unlimited
-              {{else}}{{formatNumber $limits.ApiRequestLimit}}
-              {{end}}
+              {{- if eq $limits.ApiRequestLimit 0}}unlimited
+              {{- else}}{{formatNumber $limits.ApiRequestLimit}}
+              {{- end -}}
             </td>
             <td class="num">{{formatBytes $usage.EgressBytes}}</td>
             <td class="num">
-              {{if eq $limits.EgressByteLimit 0}}unlimited
-              {{else}}{{formatBytes $limits.EgressByteLimit}}
-              {{end}}
+              {{- if eq $limits.EgressByteLimit 0}}unlimited
+              {{- else}}{{formatBytes $limits.EgressByteLimit}}
+              {{- end -}}
             </td>
             <td class="num">{{formatBytes $usage.IngressBytes}}</td>
             <td class="num">
-              {{if eq $limits.IngressByteLimit 0}}unlimited
-              {{else}}{{formatBytes $limits.IngressByteLimit}}
-              {{end}}
+              {{- if eq $limits.IngressByteLimit 0}}unlimited
+              {{- else}}{{formatBytes $limits.IngressByteLimit}}
+              {{- end -}}
             </td>
           </tr>
         {{end}}
@@ -118,6 +136,13 @@
     <h2>Objects ({{len .Data.Objects}})</h2>
     {{if .Data.Objects}}
     <table>
+      <colgroup>
+        <col style="width:15%">
+        <col style="width:40%">
+        <col style="width:12%">
+        <col style="width:13%">
+        <col style="width:20%">
+      </colgroup>
       <thead>
         <tr>
           <th>Bucket</th>


### PR DESCRIPTION
Use table-layout:fixed with colgroup elements so headers and data cells stay aligned regardless of content width.