### PR TITLE
feat: interactive collapsible object tree in dashboard

### DIFF
--- a/internal/ui/static/style.css
+++ b/internal/ui/static/style.css
@@ -138,3 +138,62 @@ td.key {
   color: #f8fafc;
   margin-top: 0.15rem;
 }
+
+/* --- Object tree --- */
+.object-tree {
+  background: #1e293b;
+  border-radius: 0.5rem;
+  padding: 0.5rem 0;
+}
+
+.tree-dir > summary {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 1rem;
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+}
+
+.tree-dir > summary::-webkit-details-marker { display: none; }
+
+.tree-dir > summary::before {
+  content: "\25b6";
+  font-size: 0.6rem;
+  color: #64748b;
+  transition: transform 0.15s;
+  flex-shrink: 0;
+}
+
+.tree-dir[open] > summary::before {
+  transform: rotate(90deg);
+}
+
+.tree-dir > summary:hover { background: #334155; }
+
+.tree-children { padding-left: 1.25rem; }
+
+.tree-file {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.3rem 1rem 0.3rem 1.85rem;
+}
+
+.tree-file:hover { background: #334155; }
+
+.tree-name {
+  font-size: 0.85rem;
+  color: #e2e8f0;
+  font-family: "SF Mono", "Fira Code", "Fira Mono", Menlo, Consolas, monospace;
+}
+
+.tree-dir > summary .tree-name { color: #93c5fd; }
+
+.tree-meta {
+  font-size: 0.75rem;
+  color: #64748b;
+  margin-left: auto;
+  white-space: nowrap;
+}

--- a/internal/ui/templates/dashboard.html
+++ b/internal/ui/templates/dashboard.html
@@ -115,30 +115,13 @@
 
   <!-- Objects -->
   <section>
-    <h2>Objects ({{len .Data.Objects}})</h2>
-    {{if .Data.Objects}}
-    <table>
-      <thead>
-        <tr>
-          <th>Bucket</th>
-          <th>Key</th>
-          <th>Backend</th>
-          <th class="num">Size</th>
-          <th class="num">Created</th>
-        </tr>
-      </thead>
-      <tbody>
-        {{range .Data.Objects}}
-          <tr>
-            <td>{{.Bucket}}</td>
-            <td class="key">{{.Key}}</td>
-            <td>{{.Backend}}</td>
-            <td class="num">{{formatBytes .SizeBytes}}</td>
-            <td class="num">{{.CreatedAt}}</td>
-          </tr>
-        {{end}}
-      </tbody>
-    </table>
+    <h2>Objects</h2>
+    {{if .Data.ObjectTree}}
+    <div class="object-tree">
+      {{range .Data.ObjectTree}}
+        {{template "treeNode" .}}
+      {{end}}
+    </div>
     {{else}}
     <p class="empty">No objects stored.</p>
     {{end}}
@@ -176,5 +159,27 @@
   </section>
 
 </div>
+
+{{define "treeNode"}}
+{{if .IsDir}}
+<details class="tree-dir">
+  <summary>
+    <span class="tree-name">{{.Name}}</span>
+    <span class="tree-meta">{{.Count}} files &middot; {{formatBytes .SizeBytes}}</span>
+  </summary>
+  <div class="tree-children">
+    {{range .Children}}
+      {{template "treeNode" .}}
+    {{end}}
+  </div>
+</details>
+{{else}}
+<div class="tree-file">
+  <span class="tree-name">{{.Name}}</span>
+  <span class="tree-meta">{{.Backend}} &middot; {{formatBytes .SizeBytes}} &middot; {{.CreatedAt}}</span>
+</div>
+{{end}}
+{{end}}
+
 </body>
 </html>


### PR DESCRIPTION
Replace flat object table with a nested tree browser using <details>/<summary> elements. Directories show file count and total size, expand on click to reveal contents.