### PR TITLE
docs: add web UI documentation, fix OTel service name

### DIFF
--- a/internal/telemetry/tracing.go
+++ b/internal/telemetry/tracing.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	// TracerName identifies spans created by this service.
-	TracerName = "s3proxy"
+	TracerName = "s3-orchestrator"
 )
 
 // Version of the service for trace metadata. Set at build time via


### PR DESCRIPTION
Add web UI section to README and admin guide covering the interactive object tree, dashboard features, and config. Update project structure and deployment docs for versioned tags. Rename OTel service.name from s3proxy to s3-orchestrator.