### PR TITLE
feat: add SIGHUP config hot-reload with tests and documentation

### DIFF
--- a/internal/integration/helpers_test.go
+++ b/internal/integration/helpers_test.go
@@ -165,9 +165,9 @@ func TestMain(m *testing.M) {
 	testManager = manager
 
 	srv := &server.Server{
-		Manager:    manager,
-		BucketAuth: auth.NewBucketRegistry(cfg.Buckets),
+		Manager: manager,
 	}
+	srv.SetBucketAuth(auth.NewBucketRegistry(cfg.Buckets))
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -591,15 +591,15 @@ func TestSpreadWriteRouting(t *testing.T) {
 	})
 
 	spreadSrv := &server.Server{
-		Manager:    spreadManager,
-		BucketAuth: auth.NewBucketRegistry([]config.BucketConfig{{
-			Name: virtualBucket,
-			Credentials: []config.CredentialConfig{{
-				AccessKeyID:    "test",
-				SecretAccessKey: "test",
-			}},
-		}}),
+		Manager: spreadManager,
 	}
+	spreadSrv.SetBucketAuth(auth.NewBucketRegistry([]config.BucketConfig{{
+		Name: virtualBucket,
+		Credentials: []config.CredentialConfig{{
+			AccessKeyID:    "test",
+			SecretAccessKey: "test",
+		}},
+	}}))
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -2607,18 +2607,18 @@ func TestAuthSigV4(t *testing.T) {
 	// Start an ephemeral server with SigV4 auth enabled, sharing the same manager.
 	authSrv := &server.Server{
 		Manager: testManager,
-		BucketAuth: auth.NewBucketRegistry([]config.BucketConfig{
-			{
-				Name: virtualBucket,
-				Credentials: []config.CredentialConfig{
-					{
-						AccessKeyID:    authKey,
-						SecretAccessKey: authSecret,
-					},
+	}
+	authSrv.SetBucketAuth(auth.NewBucketRegistry([]config.BucketConfig{
+		{
+			Name: virtualBucket,
+			Credentials: []config.CredentialConfig{
+				{
+					AccessKeyID:    authKey,
+					SecretAccessKey: authSecret,
 				},
 			},
-		}),
-	}
+		},
+	}))
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {

--- a/internal/server/ratelimit.go
+++ b/internal/server/ratelimit.go
@@ -66,6 +66,15 @@ func (rl *RateLimiter) Close() {
 	close(rl.stop)
 }
 
+// UpdateLimits changes the rate and burst for new visitors. Existing per-IP
+// limiters keep their old rates until they expire and are recreated.
+func (rl *RateLimiter) UpdateLimits(requestsPerSec float64, burst int) {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	rl.rate = rate.Limit(requestsPerSec)
+	rl.burst = burst
+}
+
 // Allow checks whether a request from the given IP is allowed.
 func (rl *RateLimiter) Allow(ip string) bool {
 	rl.mu.Lock()

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,75 @@
+package server
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/afreidah/s3-orchestrator/internal/auth"
+	"github.com/afreidah/s3-orchestrator/internal/config"
+)
+
+func TestSetGetBucketAuth_RoundTrip(t *testing.T) {
+	srv := &Server{}
+
+	buckets := []config.BucketConfig{
+		{Name: "b1", Credentials: []config.CredentialConfig{
+			{AccessKeyID: "AKID1", SecretAccessKey: "secret1"},
+		}},
+	}
+	br := auth.NewBucketRegistry(buckets)
+	srv.SetBucketAuth(br)
+
+	got := srv.GetBucketAuth()
+	if got != br {
+		t.Error("GetBucketAuth should return the same registry that was set")
+	}
+}
+
+func TestSetBucketAuth_ConcurrentAccess(t *testing.T) {
+	srv := &Server{}
+
+	// Set an initial registry
+	initial := auth.NewBucketRegistry([]config.BucketConfig{
+		{Name: "init", Credentials: []config.CredentialConfig{
+			{AccessKeyID: "AKID0", SecretAccessKey: "secret0"},
+		}},
+	})
+	srv.SetBucketAuth(initial)
+
+	var wg sync.WaitGroup
+	const goroutines = 50
+
+	// Concurrent readers
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				br := srv.GetBucketAuth()
+				if br == nil {
+					t.Error("GetBucketAuth returned nil during concurrent access")
+					return
+				}
+			}
+		}()
+	}
+
+	// Concurrent writers
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(n int) {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				br := auth.NewBucketRegistry([]config.BucketConfig{
+					{Name: "b", Credentials: []config.CredentialConfig{
+						{AccessKeyID: "AKID", SecretAccessKey: "secret"},
+					}},
+				})
+				srv.SetBucketAuth(br)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	// Test passes if no race detector violations
+}

--- a/internal/storage/manager_test.go
+++ b/internal/storage/manager_test.go
@@ -10,7 +10,11 @@
 package storage
 
 import (
+	"sync"
 	"testing"
+	"time"
+
+	"github.com/afreidah/s3-orchestrator/internal/config"
 )
 
 func TestGenerateUploadID(t *testing.T) {
@@ -26,4 +30,133 @@ func TestGenerateUploadID(t *testing.T) {
 	if id == id2 {
 		t.Error("GenerateUploadID() should produce unique IDs")
 	}
+}
+
+// -------------------------------------------------------------------------
+// UpdateUsageLimits
+// -------------------------------------------------------------------------
+
+func TestUpdateUsageLimits_SwapsLimits(t *testing.T) {
+	limits := map[string]UsageLimits{
+		"b1": {ApiRequestLimit: 100},
+	}
+	mgr := newUsageManagerWithLimits([]string{"b1"}, &mockStore{}, limits)
+
+	// Initially within limits
+	if !mgr.withinUsageLimits("b1", 50, 0, 0) {
+		t.Fatal("should be within initial limits")
+	}
+
+	// Update to a much lower limit
+	mgr.UpdateUsageLimits(map[string]UsageLimits{
+		"b1": {ApiRequestLimit: 10},
+	})
+
+	// Now 50 should exceed the new limit
+	if mgr.withinUsageLimits("b1", 50, 0, 0) {
+		t.Error("should exceed updated limit of 10")
+	}
+	// But 5 should still be within limits
+	if !mgr.withinUsageLimits("b1", 5, 0, 0) {
+		t.Error("should be within updated limit of 10")
+	}
+}
+
+// -------------------------------------------------------------------------
+// SetRebalanceConfig / RebalanceConfig
+// -------------------------------------------------------------------------
+
+func TestRebalanceConfig_RoundTrip(t *testing.T) {
+	mgr := newUsageManager([]string{"b1"}, &mockStore{})
+
+	// Initially nil
+	if mgr.RebalanceConfig() != nil {
+		t.Error("expected nil initial rebalance config")
+	}
+
+	cfg := &config.RebalanceConfig{
+		Enabled:   true,
+		Strategy:  "spread",
+		Interval:  2 * time.Hour,
+		BatchSize: 50,
+		Threshold: 0.2,
+	}
+	mgr.SetRebalanceConfig(cfg)
+
+	got := mgr.RebalanceConfig()
+	if got == nil {
+		t.Fatal("expected non-nil rebalance config")
+	}
+	if got.Strategy != "spread" || got.BatchSize != 50 || got.Threshold != 0.2 {
+		t.Errorf("rebalance config mismatch: %+v", got)
+	}
+}
+
+// -------------------------------------------------------------------------
+// SetReplicationConfig / ReplicationConfig
+// -------------------------------------------------------------------------
+
+func TestReplicationConfig_RoundTrip(t *testing.T) {
+	mgr := newUsageManager([]string{"b1"}, &mockStore{})
+
+	// Initially nil
+	if mgr.ReplicationConfig() != nil {
+		t.Error("expected nil initial replication config")
+	}
+
+	cfg := &config.ReplicationConfig{
+		Factor:         2,
+		WorkerInterval: 10 * time.Minute,
+		BatchSize:      25,
+	}
+	mgr.SetReplicationConfig(cfg)
+
+	got := mgr.ReplicationConfig()
+	if got == nil {
+		t.Fatal("expected non-nil replication config")
+	}
+	if got.Factor != 2 || got.WorkerInterval != 10*time.Minute || got.BatchSize != 25 {
+		t.Errorf("replication config mismatch: %+v", got)
+	}
+}
+
+// -------------------------------------------------------------------------
+// Concurrent Safety
+// -------------------------------------------------------------------------
+
+func TestUpdateUsageLimits_ConcurrentAccess(t *testing.T) {
+	limits := map[string]UsageLimits{
+		"b1": {ApiRequestLimit: 1000},
+	}
+	mgr := newUsageManagerWithLimits([]string{"b1"}, &mockStore{}, limits)
+
+	var wg sync.WaitGroup
+	const goroutines = 50
+
+	// Concurrent readers
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				_ = mgr.withinUsageLimits("b1", 1, 0, 0)
+			}
+		}()
+	}
+
+	// Concurrent writers
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(n int) {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				mgr.UpdateUsageLimits(map[string]UsageLimits{
+					"b1": {ApiRequestLimit: int64(n*100 + j)},
+				})
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	// Test passes if no race detector violations
 }


### PR DESCRIPTION
Reload bucket credentials, rate limits, quotas, usage limits, and rebalance/replication settings without restarting the service. Non- reloadable fields (listen_addr, database, telemetry, backend structural changes) log warnings but don't block the reload. Invalid configs are rejected entirely, keeping the current configuration.