### PR TITLE
feat: add lazy-loaded directory tree, tests, and v0.5.0 docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,9 +67,7 @@ generate: ## Generate sqlc query code
 	sqlc generate
 
 test: ## Run Go tests with coverage
-	go test -race -v -coverprofile=coverage.out ./...
-	@go tool cover -func=coverage.out | tail -1
-	@rm -f coverage.out
+	go test -race -cover ./...
 
 lint: ## Run Go linter
 	go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run ./...

--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ The dashboard shows:
 - **Objects** — interactive collapsible tree browser; buckets and directories expand on click to reveal contents, with rollup file counts and sizes
 - **Configuration** — virtual buckets, write routing strategy, replication factor, rebalance strategy, rate limit status
 
-No JavaScript required — uses native HTML `<details>/<summary>` for the tree. Enable it in the config:
+The object tree uses JavaScript for lazy-loaded AJAX expansion — directories load their children on click via the `/ui/api/tree` endpoint. Enable it in the config:
 
 ```yaml
 ui:
@@ -360,7 +360,7 @@ ui:
   path: "/ui"      # default
 ```
 
-A JSON API is also available at `{path}/api/dashboard` for programmatic access.
+JSON APIs are available at `{path}/api/dashboard` and `{path}/api/tree` for programmatic access.
 
 ## Endpoints
 
@@ -370,6 +370,7 @@ A JSON API is also available at `{path}/api/dashboard` for programmatic access.
 | `/metrics` | Prometheus metrics |
 | `/ui/` | Web dashboard (when enabled) |
 | `/ui/api/dashboard` | Dashboard data as JSON (when enabled) |
+| `/ui/api/tree` | Lazy-loaded directory listing as JSON (when enabled) |
 | `/{bucket}/{key}` | S3 API |
 
 ## Background Tasks
@@ -428,7 +429,7 @@ make integration-test
 make build
 
 # Build multi-arch and push to registry
-make push VERSION=v0.4.0
+make push VERSION=v0.5.0
 ```
 
 ## Deployment
@@ -436,7 +437,7 @@ make push VERSION=v0.4.0
 Build and push a Docker image with a version tag:
 
 ```bash
-make push VERSION=v0.4.0
+make push VERSION=v0.5.0
 ```
 
 The `VERSION` is baked into the binary via `-ldflags` and displayed in the web UI header and `/health` endpoint. Defaults to `latest` if omitted.
@@ -473,7 +474,7 @@ internal/
     manager_multipart.go     Multipart upload lifecycle
     manager_usage.go         Usage tracking flush + period helpers
     manager_metrics.go       Quota metric recording
-    manager_dashboard.go     Dashboard data aggregation + object tree builder
+    manager_dashboard.go     Dashboard data aggregation + lazy directory listing
     rebalancer.go            Object rebalancing across backends
     replicator.go            Cross-backend object replication
     sqlc/
@@ -485,6 +486,7 @@ internal/
     templates.go             Embedded templates + formatting helpers
     templates/dashboard.html Dashboard HTML template
     static/style.css         Dashboard stylesheet
+    static/tree.js           Lazy-loaded directory tree (AJAX expansion)
   telemetry/
     metrics.go               Prometheus metric definitions
     tracing.go               OpenTelemetry tracer setup

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -474,9 +474,9 @@ When `ui.enabled` is `true`, the dashboard at `{path}/` shows a live snapshot of
 - **Object tree** — interactive collapsible file browser. Buckets and directories are collapsed by default; click to expand. Each directory shows a rollup file count and total size.
 - **Configuration** — virtual bucket names, write routing strategy, replication factor, rebalance status, rate limiting
 
-The dashboard is server-rendered HTML with no JavaScript dependencies. The page shows data as of the last load — refresh the browser for updated stats.
+The dashboard is server-rendered HTML. The object tree uses JavaScript for lazy-loaded directory expansion — directories fetch their children on click via the `/ui/api/tree` endpoint.
 
-A JSON endpoint at `{path}/api/dashboard` returns the same data for programmatic access or integration with other tools.
+JSON endpoints at `{path}/api/dashboard` and `{path}/api/tree` return data for programmatic access or integration with other tools.
 
 ### Health endpoint
 
@@ -593,7 +593,7 @@ To perform a zero-downtime credential rotation, temporarily add both old and new
 make build
 
 # Multi-arch build and push to registry with version tag
-make push VERSION=v0.4.0
+make push VERSION=v0.5.0
 ```
 
 The `VERSION` is baked into the binary via `-ldflags` and displayed in the web UI and `/health` endpoint. Use versioned tags (not `latest`) to avoid Docker layer caching issues on orchestration platforms.

--- a/internal/integration/helpers_test.go
+++ b/internal/integration/helpers_test.go
@@ -436,6 +436,13 @@ func (f *FailableStore) GetStaleMultipartUploads(ctx context.Context, olderThan 
 	return f.MetadataStore.GetStaleMultipartUploads(ctx, olderThan)
 }
 
+func (f *FailableStore) ListDirectoryChildren(ctx context.Context, prefix, startAfter string, maxKeys int) (*storage.DirectoryListResult, error) {
+	if f.isFailing() {
+		return nil, errSimulatedDBFailure
+	}
+	return f.MetadataStore.ListDirectoryChildren(ctx, prefix, startAfter, maxKeys)
+}
+
 func (f *FailableStore) ListObjectsByBackend(ctx context.Context, backendName string, limit int) ([]storage.ObjectLocation, error) {
 	if f.isFailing() {
 		return nil, errSimulatedDBFailure

--- a/internal/server/list_test.go
+++ b/internal/server/list_test.go
@@ -1,0 +1,161 @@
+package server
+
+import (
+	"encoding/xml"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/afreidah/s3-orchestrator/internal/storage"
+)
+
+func TestListObjectsV2_Success(t *testing.T) {
+	ts, mockStore, _ := newTestServer(t)
+	now := time.Now()
+
+	mockStore.listObjectsResp = &storage.ListObjectsResult{
+		Objects: []storage.ObjectLocation{
+			{ObjectKey: "mybucket/file1.txt", BackendName: "b1", SizeBytes: 100, CreatedAt: now},
+			{ObjectKey: "mybucket/file2.txt", BackendName: "b1", SizeBytes: 200, CreatedAt: now},
+		},
+	}
+
+	resp := doReq(t, http.MethodGet, ts.URL+"/mybucket/?list-type=2", nil)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	xmlBody := string(body)
+
+	// Verify XML structure
+	if !strings.Contains(xmlBody, "<ListBucketResult") {
+		t.Error("response missing ListBucketResult element")
+	}
+
+	// Verify keys have bucket prefix stripped
+	if strings.Contains(xmlBody, "mybucket/file1.txt") {
+		t.Error("keys should have bucket prefix stripped")
+	}
+	if !strings.Contains(xmlBody, "<Key>file1.txt</Key>") {
+		t.Error("expected stripped key file1.txt")
+	}
+	if !strings.Contains(xmlBody, "<Key>file2.txt</Key>") {
+		t.Error("expected stripped key file2.txt")
+	}
+}
+
+func TestListObjectsV2_WithDelimiter(t *testing.T) {
+	ts, mockStore, _ := newTestServer(t)
+	now := time.Now()
+
+	// Return objects with a common directory prefix
+	mockStore.listObjectsResp = &storage.ListObjectsResult{
+		Objects: []storage.ObjectLocation{
+			{ObjectKey: "mybucket/photos/a.jpg", BackendName: "b1", SizeBytes: 100, CreatedAt: now},
+			{ObjectKey: "mybucket/photos/b.jpg", BackendName: "b1", SizeBytes: 200, CreatedAt: now},
+			{ObjectKey: "mybucket/readme.txt", BackendName: "b1", SizeBytes: 50, CreatedAt: now},
+		},
+	}
+
+	resp := doReq(t, http.MethodGet, ts.URL+"/mybucket/?delimiter=/", nil)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	xmlBody := string(body)
+
+	// Should have common prefix for photos/
+	if !strings.Contains(xmlBody, "<Prefix>photos/</Prefix>") {
+		t.Error("expected common prefix photos/")
+	}
+	// Should have readme.txt as content
+	if !strings.Contains(xmlBody, "<Key>readme.txt</Key>") {
+		t.Error("expected key readme.txt")
+	}
+}
+
+func TestListObjectsV2_Pagination(t *testing.T) {
+	ts, mockStore, _ := newTestServer(t)
+	now := time.Now()
+
+	// Return 3 objects when maxKeys=2. The manager will take the first 2 and
+	// set IsTruncated=true with a NextContinuationToken.
+	mockStore.listObjectsResp = &storage.ListObjectsResult{
+		Objects: []storage.ObjectLocation{
+			{ObjectKey: "mybucket/a.txt", BackendName: "b1", SizeBytes: 10, CreatedAt: now},
+			{ObjectKey: "mybucket/b.txt", BackendName: "b1", SizeBytes: 20, CreatedAt: now},
+			{ObjectKey: "mybucket/c.txt", BackendName: "b1", SizeBytes: 30, CreatedAt: now},
+		},
+	}
+
+	resp := doReq(t, http.MethodGet, ts.URL+"/mybucket/?max-keys=2", nil)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+
+	type listResult struct {
+		XMLName               xml.Name `xml:"ListBucketResult"`
+		IsTruncated           bool     `xml:"IsTruncated"`
+		NextContinuationToken string   `xml:"NextContinuationToken"`
+		KeyCount              int      `xml:"KeyCount"`
+	}
+	var result listResult
+	if err := xml.Unmarshal(body, &result); err != nil {
+		t.Fatalf("failed to parse XML: %v", err)
+	}
+	if !result.IsTruncated {
+		t.Error("expected IsTruncated=true")
+	}
+	if result.KeyCount != 2 {
+		t.Errorf("KeyCount = %d, want 2", result.KeyCount)
+	}
+	// NextContinuationToken should have bucket prefix stripped
+	if strings.HasPrefix(result.NextContinuationToken, "mybucket/") {
+		t.Error("NextContinuationToken should have bucket prefix stripped")
+	}
+}
+
+func TestListObjectsV2_Empty(t *testing.T) {
+	ts, mockStore, _ := newTestServer(t)
+
+	mockStore.listObjectsResp = &storage.ListObjectsResult{
+		Objects: []storage.ObjectLocation{},
+	}
+
+	resp := doReq(t, http.MethodGet, ts.URL+"/mybucket/", nil)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+
+	type listResult struct {
+		XMLName     xml.Name `xml:"ListBucketResult"`
+		IsTruncated bool     `xml:"IsTruncated"`
+		KeyCount    int      `xml:"KeyCount"`
+	}
+	var result listResult
+	if err := xml.Unmarshal(body, &result); err != nil {
+		t.Fatalf("failed to parse XML: %v", err)
+	}
+	if result.IsTruncated {
+		t.Error("expected IsTruncated=false for empty result")
+	}
+	if result.KeyCount != 0 {
+		t.Errorf("KeyCount = %d, want 0", result.KeyCount)
+	}
+}

--- a/internal/storage/circuitbreaker.go
+++ b/internal/storage/circuitbreaker.go
@@ -239,6 +239,12 @@ func (cb *CircuitBreakerStore) ListObjects(ctx context.Context, prefix, startAft
 	return cbCall(cb, func() (*ListObjectsResult, error) { return cb.real.ListObjects(ctx, prefix, startAfter, maxKeys) })
 }
 
+func (cb *CircuitBreakerStore) ListDirectoryChildren(ctx context.Context, prefix, startAfter string, maxKeys int) (*DirectoryListResult, error) {
+	return cbCall(cb, func() (*DirectoryListResult, error) {
+		return cb.real.ListDirectoryChildren(ctx, prefix, startAfter, maxKeys)
+	})
+}
+
 func (cb *CircuitBreakerStore) GetBackendWithSpace(ctx context.Context, size int64, backendOrder []string) (string, error) {
 	return cbCall(cb, func() (string, error) { return cb.real.GetBackendWithSpace(ctx, size, backendOrder) })
 }

--- a/internal/storage/manager_dashboard_test.go
+++ b/internal/storage/manager_dashboard_test.go
@@ -1,0 +1,154 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestGetDashboardData_Success(t *testing.T) {
+	store := &mockStore{
+		getQuotaStatsResp: map[string]QuotaStat{
+			"b1": {BackendName: "b1", BytesUsed: 500, BytesLimit: 1000},
+		},
+		getObjectCountsResp:    map[string]int64{"b1": 42},
+		getActiveMultipartResp: map[string]int64{"b1": 3},
+		getUsageForPeriodResp:  map[string]UsageStat{"b1": {ApiRequests: 100}},
+		listDirChildrenResp: &DirectoryListResult{
+			Entries: []DirEntry{
+				{Name: "bucket1/", IsDir: true, FileCount: 10, TotalSize: 4096},
+			},
+		},
+	}
+	mgr := newTestManager(store, map[string]*mockBackend{"b1": newMockBackend()})
+	defer mgr.Close()
+
+	data, err := mgr.GetDashboardData(context.Background())
+	if err != nil {
+		t.Fatalf("GetDashboardData: %v", err)
+	}
+
+	if len(data.QuotaStats) != 1 {
+		t.Errorf("QuotaStats count = %d, want 1", len(data.QuotaStats))
+	}
+	if data.ObjectCounts["b1"] != 42 {
+		t.Errorf("ObjectCounts[b1] = %d, want 42", data.ObjectCounts["b1"])
+	}
+	if data.ActiveMultipartCounts["b1"] != 3 {
+		t.Errorf("ActiveMultipartCounts[b1] = %d, want 3", data.ActiveMultipartCounts["b1"])
+	}
+	if data.UsageStats["b1"].ApiRequests != 100 {
+		t.Errorf("UsageStats[b1].ApiRequests = %d, want 100", data.UsageStats["b1"].ApiRequests)
+	}
+	if len(data.TopLevelEntries.Entries) != 1 {
+		t.Errorf("TopLevelEntries count = %d, want 1", len(data.TopLevelEntries.Entries))
+	}
+	if data.UsagePeriod == "" {
+		t.Error("UsagePeriod should not be empty")
+	}
+}
+
+func TestGetDashboardData_QuotaStatsError(t *testing.T) {
+	store := &mockStore{
+		getQuotaStatsErr: errors.New("db error"),
+	}
+	mgr := newTestManager(store, map[string]*mockBackend{"b1": newMockBackend()})
+	defer mgr.Close()
+
+	_, err := mgr.GetDashboardData(context.Background())
+	if err == nil {
+		t.Fatal("expected error from GetDashboardData")
+	}
+}
+
+func TestGetDashboardData_ObjectCountsError(t *testing.T) {
+	store := &mockStore{
+		getQuotaStatsResp:  map[string]QuotaStat{"b1": {}},
+		getObjectCountsErr: errors.New("db error"),
+	}
+	mgr := newTestManager(store, map[string]*mockBackend{"b1": newMockBackend()})
+	defer mgr.Close()
+
+	_, err := mgr.GetDashboardData(context.Background())
+	if err == nil {
+		t.Fatal("expected error from GetDashboardData")
+	}
+}
+
+func TestGetDashboardData_MultipartCountsError(t *testing.T) {
+	store := &mockStore{
+		getQuotaStatsResp:   map[string]QuotaStat{"b1": {}},
+		getObjectCountsResp: map[string]int64{"b1": 0},
+		getActiveMultipartErr: errors.New("db error"),
+	}
+	mgr := newTestManager(store, map[string]*mockBackend{"b1": newMockBackend()})
+	defer mgr.Close()
+
+	_, err := mgr.GetDashboardData(context.Background())
+	if err == nil {
+		t.Fatal("expected error from GetDashboardData")
+	}
+}
+
+func TestGetDashboardData_UsageForPeriodError(t *testing.T) {
+	store := &mockStore{
+		getQuotaStatsResp:      map[string]QuotaStat{"b1": {}},
+		getObjectCountsResp:    map[string]int64{"b1": 0},
+		getActiveMultipartResp: map[string]int64{"b1": 0},
+		getUsageForPeriodErr:   errors.New("db error"),
+	}
+	mgr := newTestManager(store, map[string]*mockBackend{"b1": newMockBackend()})
+	defer mgr.Close()
+
+	_, err := mgr.GetDashboardData(context.Background())
+	if err == nil {
+		t.Fatal("expected error from GetDashboardData")
+	}
+}
+
+func TestGetDashboardData_ListDirChildrenError(t *testing.T) {
+	store := &mockStore{
+		getQuotaStatsResp:      map[string]QuotaStat{"b1": {}},
+		getObjectCountsResp:    map[string]int64{"b1": 0},
+		getActiveMultipartResp: map[string]int64{"b1": 0},
+		getUsageForPeriodResp:  map[string]UsageStat{},
+		listDirChildrenErr:     errors.New("db error"),
+	}
+	mgr := newTestManager(store, map[string]*mockBackend{"b1": newMockBackend()})
+	defer mgr.Close()
+
+	_, err := mgr.GetDashboardData(context.Background())
+	if err == nil {
+		t.Fatal("expected error from GetDashboardData")
+	}
+}
+
+func TestGetDirectoryChildren_CapsMaxKeys(t *testing.T) {
+	store := &mockStore{
+		listDirChildrenResp: &DirectoryListResult{},
+	}
+	mgr := newTestManager(store, map[string]*mockBackend{"b1": newMockBackend()})
+	defer mgr.Close()
+
+	tests := []struct {
+		name    string
+		maxKeys int
+	}{
+		{"zero becomes 200", 0},
+		{"negative becomes 200", -5},
+		{"over 200 becomes 200", 500},
+		{"valid stays valid", 50},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := mgr.GetDirectoryChildren(context.Background(), "", "", tt.maxKeys)
+			if err != nil {
+				t.Fatalf("GetDirectoryChildren: %v", err)
+			}
+			if result == nil {
+				t.Fatal("expected non-nil result")
+			}
+		})
+	}
+}

--- a/internal/storage/metadata.go
+++ b/internal/storage/metadata.go
@@ -62,6 +62,9 @@ type MetadataStore interface {
 	GetParts(ctx context.Context, uploadID string) ([]MultipartPart, error)
 	DeleteMultipartUpload(ctx context.Context, uploadID string) error
 
+	// --- Directory listing (dashboard) ---
+	ListDirectoryChildren(ctx context.Context, prefix, startAfter string, maxKeys int) (*DirectoryListResult, error)
+
 	// --- Background operations (metrics, cleanup, rebalance, replication) ---
 	GetQuotaStats(ctx context.Context) (map[string]QuotaStat, error)
 	GetObjectCounts(ctx context.Context) (map[string]int64, error)

--- a/internal/storage/mock_store_test.go
+++ b/internal/storage/mock_store_test.go
@@ -37,6 +37,18 @@ type mockStore struct {
 	deleteMultipartErr error
 	recordPartErr      error
 
+	// Dashboard / background
+	getQuotaStatsResp          map[string]QuotaStat
+	getQuotaStatsErr           error
+	getObjectCountsResp        map[string]int64
+	getObjectCountsErr         error
+	getActiveMultipartResp     map[string]int64
+	getActiveMultipartErr      error
+	getUsageForPeriodResp      map[string]UsageStat
+	getUsageForPeriodErr       error
+	listDirChildrenResp        *DirectoryListResult
+	listDirChildrenErr         error
+
 	// Usage tracking
 	flushUsageErr   error
 	flushUsageCalls []flushUsageCall
@@ -166,18 +178,46 @@ func (m *mockStore) DeleteMultipartUpload(_ context.Context, _ string) error {
 	return m.deleteMultipartErr
 }
 
+func (m *mockStore) ListDirectoryChildren(_ context.Context, _, _ string, _ int) (*DirectoryListResult, error) {
+	if m.listDirChildrenErr != nil {
+		return nil, m.listDirChildrenErr
+	}
+	if m.listDirChildrenResp != nil {
+		return m.listDirChildrenResp, nil
+	}
+	return &DirectoryListResult{}, nil
+}
+
 // --- Background operations (stubs) ---
 
 func (m *mockStore) GetQuotaStats(_ context.Context) (map[string]QuotaStat, error) {
-	return nil, nil
+	if m.getQuotaStatsErr != nil {
+		return nil, m.getQuotaStatsErr
+	}
+	if m.getQuotaStatsResp != nil {
+		return m.getQuotaStatsResp, nil
+	}
+	return map[string]QuotaStat{}, nil
 }
 
 func (m *mockStore) GetObjectCounts(_ context.Context) (map[string]int64, error) {
-	return nil, nil
+	if m.getObjectCountsErr != nil {
+		return nil, m.getObjectCountsErr
+	}
+	if m.getObjectCountsResp != nil {
+		return m.getObjectCountsResp, nil
+	}
+	return map[string]int64{}, nil
 }
 
 func (m *mockStore) GetActiveMultipartCounts(_ context.Context) (map[string]int64, error) {
-	return nil, nil
+	if m.getActiveMultipartErr != nil {
+		return nil, m.getActiveMultipartErr
+	}
+	if m.getActiveMultipartResp != nil {
+		return m.getActiveMultipartResp, nil
+	}
+	return map[string]int64{}, nil
 }
 
 func (m *mockStore) GetStaleMultipartUploads(_ context.Context, _ time.Duration) ([]MultipartUpload, error) {
@@ -214,5 +254,11 @@ func (m *mockStore) FlushUsageDeltas(_ context.Context, backendName, period stri
 }
 
 func (m *mockStore) GetUsageForPeriod(_ context.Context, _ string) (map[string]UsageStat, error) {
-	return nil, nil
+	if m.getUsageForPeriodErr != nil {
+		return nil, m.getUsageForPeriodErr
+	}
+	if m.getUsageForPeriodResp != nil {
+		return m.getUsageForPeriodResp, nil
+	}
+	return map[string]UsageStat{}, nil
 }

--- a/internal/storage/sqlc/queries/objects.sql
+++ b/internal/storage/sqlc/queries/objects.sql
@@ -54,3 +54,34 @@ INSERT INTO object_locations (object_key, backend_name, size_bytes, created_at)
 VALUES ($1, $2, $3, NOW())
 ON CONFLICT (object_key, backend_name) DO NOTHING
 RETURNING true AS inserted;
+
+-- name: GetDirectoryStats :many
+-- Aggregate count and size for immediate children of a directory prefix.
+-- Directories (containing a '/') and files are distinguished by is_dir.
+SELECT
+    (CASE WHEN position('/' IN substring(object_key FROM length(@prefix::text) + 1)) > 0
+         THEN substring(object_key FROM length(@prefix::text) + 1
+              FOR position('/' IN substring(object_key FROM length(@prefix::text) + 1)))
+         ELSE substring(object_key FROM length(@prefix::text) + 1)
+    END)::text AS name,
+    (CASE WHEN position('/' IN substring(object_key FROM length(@prefix::text) + 1)) > 0
+         THEN true ELSE false
+    END)::boolean AS is_dir,
+    COUNT(DISTINCT object_key)  AS file_count,
+    COALESCE(SUM(size_bytes), 0)::bigint AS total_size
+FROM object_locations
+WHERE object_key LIKE @prefix::text || '%' ESCAPE '\'
+  AND length(object_key) > length(@prefix::text)
+GROUP BY name, is_dir
+ORDER BY is_dir DESC, name ASC;
+
+-- name: ListDirectChildren :many
+-- Return per-file detail for non-directory children under a prefix, with pagination.
+SELECT DISTINCT ON (object_key) object_key, backend_name, size_bytes, created_at
+FROM object_locations
+WHERE object_key LIKE @prefix::text || '%' ESCAPE '\'
+  AND position('/' IN substring(object_key FROM length(@prefix::text) + 1)) = 0
+  AND length(object_key) > length(@prefix::text)
+  AND object_key > @start_after
+ORDER BY object_key, created_at ASC
+LIMIT @max_keys;

--- a/internal/ui/handler_test.go
+++ b/internal/ui/handler_test.go
@@ -1,0 +1,223 @@
+package ui
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/afreidah/s3-orchestrator/internal/config"
+	"github.com/afreidah/s3-orchestrator/internal/storage"
+)
+
+// uiMockStore implements storage.MetadataStore for UI handler tests.
+type uiMockStore struct {
+	quotaStats      map[string]storage.QuotaStat
+	objectCounts    map[string]int64
+	multipartCounts map[string]int64
+	usageStats      map[string]storage.UsageStat
+	dirChildren     *storage.DirectoryListResult
+}
+
+func (m *uiMockStore) GetAllObjectLocations(_ context.Context, _ string) ([]storage.ObjectLocation, error) {
+	return nil, storage.ErrObjectNotFound
+}
+func (m *uiMockStore) RecordObject(_ context.Context, _, _ string, _ int64) error { return nil }
+func (m *uiMockStore) DeleteObject(_ context.Context, _ string) ([]storage.DeletedCopy, error) {
+	return nil, nil
+}
+func (m *uiMockStore) ListObjects(_ context.Context, _, _ string, _ int) (*storage.ListObjectsResult, error) {
+	return &storage.ListObjectsResult{}, nil
+}
+func (m *uiMockStore) GetBackendWithSpace(_ context.Context, _ int64, _ []string) (string, error) {
+	return "b1", nil
+}
+func (m *uiMockStore) GetLeastUtilizedBackend(_ context.Context, _ int64, _ []string) (string, error) {
+	return "b1", nil
+}
+func (m *uiMockStore) CreateMultipartUpload(_ context.Context, _, _, _, _ string) error { return nil }
+func (m *uiMockStore) GetMultipartUpload(_ context.Context, _ string) (*storage.MultipartUpload, error) {
+	return nil, nil
+}
+func (m *uiMockStore) RecordPart(_ context.Context, _ string, _ int, _ string, _ int64) error {
+	return nil
+}
+func (m *uiMockStore) GetParts(_ context.Context, _ string) ([]storage.MultipartPart, error) {
+	return nil, nil
+}
+func (m *uiMockStore) DeleteMultipartUpload(_ context.Context, _ string) error { return nil }
+func (m *uiMockStore) ListDirectoryChildren(_ context.Context, _, _ string, _ int) (*storage.DirectoryListResult, error) {
+	if m.dirChildren != nil {
+		return m.dirChildren, nil
+	}
+	return &storage.DirectoryListResult{}, nil
+}
+func (m *uiMockStore) GetQuotaStats(_ context.Context) (map[string]storage.QuotaStat, error) {
+	return m.quotaStats, nil
+}
+func (m *uiMockStore) GetObjectCounts(_ context.Context) (map[string]int64, error) {
+	return m.objectCounts, nil
+}
+func (m *uiMockStore) GetActiveMultipartCounts(_ context.Context) (map[string]int64, error) {
+	return m.multipartCounts, nil
+}
+func (m *uiMockStore) GetStaleMultipartUploads(_ context.Context, _ time.Duration) ([]storage.MultipartUpload, error) {
+	return nil, nil
+}
+func (m *uiMockStore) ListObjectsByBackend(_ context.Context, _ string, _ int) ([]storage.ObjectLocation, error) {
+	return nil, nil
+}
+func (m *uiMockStore) MoveObjectLocation(_ context.Context, _, _, _ string) (int64, error) {
+	return 0, nil
+}
+func (m *uiMockStore) GetUnderReplicatedObjects(_ context.Context, _, _ int) ([]storage.ObjectLocation, error) {
+	return nil, nil
+}
+func (m *uiMockStore) RecordReplica(_ context.Context, _, _, _ string, _ int64) (bool, error) {
+	return false, nil
+}
+func (m *uiMockStore) FlushUsageDeltas(_ context.Context, _, _ string, _, _, _ int64) error {
+	return nil
+}
+func (m *uiMockStore) GetUsageForPeriod(_ context.Context, _ string) (map[string]storage.UsageStat, error) {
+	return m.usageStats, nil
+}
+
+// newTestHandler builds a Handler wired to mock data for testing.
+func newTestHandler(t *testing.T) (*Handler, *http.ServeMux) {
+	t.Helper()
+
+	mockStore := &uiMockStore{
+		quotaStats: map[string]storage.QuotaStat{
+			"b1": {BackendName: "b1", BytesUsed: 500, BytesLimit: 1000},
+		},
+		objectCounts:    map[string]int64{"b1": 42},
+		multipartCounts: map[string]int64{"b1": 0},
+		usageStats:      map[string]storage.UsageStat{"b1": {ApiRequests: 100}},
+		dirChildren: &storage.DirectoryListResult{
+			Entries: []storage.DirEntry{
+				{Name: "bucket1/", IsDir: true, FileCount: 10, TotalSize: 4096},
+			},
+		},
+	}
+
+	// mockBackend satisfies ObjectBackend — unused but needed for NewBackendManager.
+	mgr := storage.NewBackendManager(&storage.BackendManagerConfig{
+		Backends:        map[string]storage.ObjectBackend{},
+		Store:           mockStore,
+		Order:           []string{"b1"},
+		RoutingStrategy: "pack",
+	})
+	t.Cleanup(mgr.Close)
+
+	cfg := &config.Config{
+		Buckets: []config.BucketConfig{
+			{Name: "test-bucket"},
+		},
+		RoutingStrategy: "pack",
+		Replication:     config.ReplicationConfig{Factor: 1},
+		RateLimit:       config.RateLimitConfig{Enabled: false},
+	}
+
+	h := New(mgr, func() bool { return true }, cfg)
+
+	mux := http.NewServeMux()
+	h.Register(mux, "/ui")
+
+	return h, mux
+}
+
+func TestDashboard_Returns200HTML(t *testing.T) {
+	_, mux := newTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/ui/", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	ct := resp.Header.Get("Content-Type")
+	if !strings.Contains(ct, "text/html") {
+		t.Errorf("Content-Type = %q, want text/html", ct)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "S3 Orchestrator") {
+		t.Error("response body missing expected title")
+	}
+	if !strings.Contains(string(body), "Backends") {
+		t.Error("response body missing Backends section")
+	}
+}
+
+func TestAPIDashboard_ReturnsJSON(t *testing.T) {
+	_, mux := newTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/ui/api/dashboard", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	ct := resp.Header.Get("Content-Type")
+	if !strings.Contains(ct, "application/json") {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+
+	var data storage.DashboardData
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		t.Fatalf("failed to decode JSON: %v", err)
+	}
+	if len(data.QuotaStats) == 0 {
+		t.Error("expected non-empty QuotaStats")
+	}
+}
+
+func TestTreeAPI_ReturnsJSON(t *testing.T) {
+	_, mux := newTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/ui/api/tree?prefix=", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	ct := resp.Header.Get("Content-Type")
+	if !strings.Contains(ct, "application/json") {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+
+	var result storage.DirectoryListResult
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("failed to decode JSON: %v", err)
+	}
+	if len(result.Entries) == 0 {
+		t.Error("expected entries in tree response")
+	}
+}
+
+func TestStaticCSS_Returns200(t *testing.T) {
+	_, mux := newTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/ui/static/style.css", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	ct := resp.Header.Get("Content-Type")
+	if !strings.Contains(ct, "css") {
+		t.Errorf("Content-Type = %q, want text/css", ct)
+	}
+}

--- a/internal/ui/static/style.css
+++ b/internal/ui/static/style.css
@@ -197,3 +197,21 @@ td.key {
   margin-left: auto;
   white-space: nowrap;
 }
+
+.tree-loading {
+  padding: 0.3rem 1rem 0.3rem 1.85rem;
+  font-size: 0.8rem;
+  color: #64748b;
+  font-style: italic;
+}
+
+.tree-load-more {
+  padding: 0.3rem 1rem 0.3rem 1.85rem;
+  font-size: 0.8rem;
+  color: #93c5fd;
+  cursor: pointer;
+}
+
+.tree-load-more:hover {
+  background: #334155;
+}

--- a/internal/ui/static/tree.js
+++ b/internal/ui/static/tree.js
@@ -1,0 +1,112 @@
+// -------------------------------------------------------------------------------
+// Tree - Lazy-loaded directory expansion for the object browser
+//
+// Author: Alex Freidah
+//
+// Intercepts <details> open events on directory nodes and fetches children from
+// the /ui/api/tree endpoint. Renders the response into the same HTML structure
+// as server-rendered nodes. Supports pagination via "load more" links.
+// -------------------------------------------------------------------------------
+
+(function () {
+  'use strict';
+
+  var tree = document.getElementById('object-tree');
+  if (!tree) return;
+
+  tree.addEventListener('toggle', function (e) {
+    var details = e.target;
+    if (!details.open || details.dataset.loaded === 'true') return;
+    if (!details.classList.contains('tree-dir')) return;
+
+    details.dataset.loaded = 'true';
+    loadChildren(details.dataset.prefix, '', details.querySelector('.tree-children'));
+  }, true);
+
+  function loadChildren(prefix, startAfter, container) {
+    var url = 'api/tree?prefix=' + encodeURIComponent(prefix);
+    if (startAfter) url += '&startAfter=' + encodeURIComponent(startAfter);
+
+    fetch(url)
+      .then(function (resp) {
+        if (!resp.ok) throw new Error('HTTP ' + resp.status);
+        return resp.json();
+      })
+      .then(function (data) {
+        var loading = container.querySelector('.tree-loading');
+        if (loading) loading.remove();
+
+        var existing = container.querySelector('.tree-load-more');
+        if (existing) existing.remove();
+
+        var entries = data.entries || [];
+        for (var i = 0; i < entries.length; i++) {
+          container.appendChild(renderEntry(entries[i]));
+        }
+
+        if (data.hasMore && data.nextCursor) {
+          var btn = document.createElement('div');
+          btn.className = 'tree-load-more';
+          btn.textContent = 'Load more\u2026';
+          btn.addEventListener('click', function () {
+            btn.textContent = 'Loading\u2026';
+            loadChildren(prefix, data.nextCursor, container);
+          });
+          container.appendChild(btn);
+        }
+      })
+      .catch(function (err) {
+        var loading = container.querySelector('.tree-loading');
+        if (loading) loading.textContent = 'Failed to load';
+        console.error('Tree load error:', err);
+      });
+  }
+
+  function renderEntry(entry) {
+    if (entry.isDir) {
+      var details = document.createElement('details');
+      details.className = 'tree-dir';
+      details.dataset.prefix = entry.name;
+      details.dataset.loaded = 'false';
+
+      var summary = document.createElement('summary');
+      summary.innerHTML =
+        '<span class="tree-name">' + escapeHtml(entry.name) + '</span>' +
+        '<span class="tree-meta">' + entry.fileCount + ' files &middot; ' + formatBytes(entry.totalSize) + '</span>';
+      details.appendChild(summary);
+
+      var children = document.createElement('div');
+      children.className = 'tree-children';
+      var loadingDiv = document.createElement('div');
+      loadingDiv.className = 'tree-loading';
+      loadingDiv.textContent = 'Loading\u2026';
+      children.appendChild(loadingDiv);
+      details.appendChild(children);
+
+      return details;
+    }
+
+    var div = document.createElement('div');
+    div.className = 'tree-file';
+    div.innerHTML =
+      '<span class="tree-name">' + escapeHtml(entry.name.split('/').pop()) + '</span>' +
+      '<span class="tree-meta">' + escapeHtml(entry.backend) + ' &middot; ' +
+      formatBytes(entry.totalSize) + ' &middot; ' + escapeHtml(entry.createdAt) + '</span>';
+    return div;
+  }
+
+  function formatBytes(b) {
+    if (b === 0) return '0 B';
+    var units = ['B', 'KiB', 'MiB', 'GiB', 'TiB'];
+    var i = 0;
+    while (b >= 1024 && i < units.length - 1) { b /= 1024; i++; }
+    return (i === 0 ? b : b.toFixed(1)) + ' ' + units[i];
+  }
+
+  function escapeHtml(s) {
+    if (!s) return '';
+    var d = document.createElement('div');
+    d.textContent = s;
+    return d.innerHTML;
+  }
+})();

--- a/internal/ui/templates/dashboard.html
+++ b/internal/ui/templates/dashboard.html
@@ -117,10 +117,25 @@
   <!-- Objects -->
   <section>
     <h2>Objects</h2>
-    {{if .Data.ObjectTree}}
-    <div class="object-tree">
-      {{range .Data.ObjectTree}}
-        {{template "treeNode" .}}
+    {{if .Data.TopLevelEntries.Entries}}
+    <div class="object-tree" id="object-tree">
+      {{range .Data.TopLevelEntries.Entries}}
+        {{if .IsDir}}
+        <details class="tree-dir" data-prefix="{{.Name}}" data-loaded="false">
+          <summary>
+            <span class="tree-name">{{.Name}}</span>
+            <span class="tree-meta">{{.FileCount}} files &middot; {{formatBytes .TotalSize}}</span>
+          </summary>
+          <div class="tree-children">
+            <div class="tree-loading">Loading&hellip;</div>
+          </div>
+        </details>
+        {{else}}
+        <div class="tree-file">
+          <span class="tree-name">{{.Name}}</span>
+          <span class="tree-meta">{{.Backend}} &middot; {{formatBytes .TotalSize}} &middot; {{.CreatedAt}}</span>
+        </div>
+        {{end}}
       {{end}}
     </div>
     {{else}}
@@ -165,26 +180,6 @@
 
 </div>
 
-{{define "treeNode"}}
-{{if .IsDir}}
-<details class="tree-dir">
-  <summary>
-    <span class="tree-name">{{.Name}}</span>
-    <span class="tree-meta">{{.Count}} files &middot; {{formatBytes .SizeBytes}}</span>
-  </summary>
-  <div class="tree-children">
-    {{range .Children}}
-      {{template "treeNode" .}}
-    {{end}}
-  </div>
-</details>
-{{else}}
-<div class="tree-file">
-  <span class="tree-name">{{.Name}}</span>
-  <span class="tree-meta">{{.Backend}} &middot; {{formatBytes .SizeBytes}} &middot; {{.CreatedAt}}</span>
-</div>
-{{end}}
-{{end}}
-
+<script src="static/tree.js?v={{.Version}}"></script>
 </body>
 </html>

--- a/internal/ui/templates_test.go
+++ b/internal/ui/templates_test.go
@@ -1,0 +1,115 @@
+package ui
+
+import "testing"
+
+func TestFormatBytes(t *testing.T) {
+	tests := []struct {
+		input int64
+		want  string
+	}{
+		{0, "0 B"},
+		{1, "1 B"},
+		{512, "512 B"},
+		{1023, "1023 B"},
+		{1024, "1.0 KiB"},
+		{1536, "1.5 KiB"},
+		{1048576, "1.0 MiB"},
+		{1073741824, "1.0 GiB"},
+		{1099511627776, "1.0 TiB"},
+	}
+
+	for _, tt := range tests {
+		got := formatBytes(tt.input)
+		if got != tt.want {
+			t.Errorf("formatBytes(%d) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestFormatNumber(t *testing.T) {
+	tests := []struct {
+		input int64
+		want  string
+	}{
+		{0, "0"},
+		{1, "1"},
+		{999, "999"},
+		{1000, "1,000"},
+		{12345, "12,345"},
+		{1000000, "1,000,000"},
+		{-42, "-42"},
+		{-1234, "-1,234"},
+	}
+
+	for _, tt := range tests {
+		got := formatNumber(tt.input)
+		if got != tt.want {
+			t.Errorf("formatNumber(%d) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestPct(t *testing.T) {
+	tests := []struct {
+		used, limit int64
+		want        string
+	}{
+		{50, 100, "50.0%"},
+		{1, 3, "33.3%"},
+		{0, 100, "0.0%"},
+		{100, 100, "100.0%"},
+		{0, 0, "unlimited"},
+		{500, 0, "unlimited"},
+	}
+
+	for _, tt := range tests {
+		got := pct(tt.used, tt.limit)
+		if got != tt.want {
+			t.Errorf("pct(%d, %d) = %q, want %q", tt.used, tt.limit, got, tt.want)
+		}
+	}
+}
+
+func TestPctFloat(t *testing.T) {
+	tests := []struct {
+		used, limit int64
+		want        float64
+	}{
+		{50, 100, 50.0},
+		{0, 100, 0.0},
+		{100, 100, 100.0},
+		{150, 100, 100.0}, // capped at 100
+		{0, 0, 0.0},       // unlimited
+		{500, 0, 0.0},     // unlimited
+	}
+
+	for _, tt := range tests {
+		got := pctFloat(tt.used, tt.limit)
+		if got != tt.want {
+			t.Errorf("pctFloat(%d, %d) = %f, want %f", tt.used, tt.limit, got, tt.want)
+		}
+	}
+}
+
+func TestBarColor(t *testing.T) {
+	tests := []struct {
+		used, limit int64
+		want        string
+	}{
+		{50, 100, "#22c55e"},  // green (<70%)
+		{69, 100, "#22c55e"},  // green (69%)
+		{70, 100, "#f59e0b"},  // amber (70%)
+		{85, 100, "#f59e0b"},  // amber (85%)
+		{90, 100, "#ef4444"},  // red (90%)
+		{100, 100, "#ef4444"}, // red (100%)
+		{0, 0, "#6b7280"},    // gray (unlimited)
+		{500, 0, "#6b7280"},  // gray (unlimited)
+	}
+
+	for _, tt := range tests {
+		got := barColor(tt.used, tt.limit)
+		if got != tt.want {
+			t.Errorf("barColor(%d, %d) = %q, want %q", tt.used, tt.limit, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
Replace the server-rendered HTML object tree with a lazy-loaded AJAX tree that fetches directory children on click via /ui/api/tree. Add new SQL query (ListDirectoryChildren), handler, and JS client.

Add unit tests for server handlers (PUT/GET/HEAD/DELETE/COPY, list), UI handlers and template helpers, and storage dashboard aggregation. Coverage: server 15.9%→67.9%, ui 0%→82.1%.

Update docs to reflect JS-based tree and bump version examples to v0.5.0. Simplify make test output to show per-package coverage.