### PR TITLE
feat: add service lifecycle manager with panic recovery and auto-restart

### DIFF
--- a/cmd/s3-orchestrator/services.go
+++ b/cmd/s3-orchestrator/services.go
@@ -1,0 +1,147 @@
+// -------------------------------------------------------------------------------
+// Background Service Definitions
+//
+// Author: Alex Freidah
+//
+// Service types for the lifecycle manager. Each wraps one of the four periodic
+// background tasks (usage flush, multipart cleanup, rebalancer, replicator)
+// behind the lifecycle.Service interface.
+// -------------------------------------------------------------------------------
+
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/afreidah/s3-orchestrator/internal/storage"
+)
+
+// -------------------------------------------------------------------------
+// USAGE FLUSH
+// -------------------------------------------------------------------------
+
+type usageFlushService struct {
+	manager *storage.BackendManager
+}
+
+func (s *usageFlushService) Run(ctx context.Context) error {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			if err := s.manager.FlushUsage(ctx); err != nil && !errors.Is(err, storage.ErrDBUnavailable) {
+				slog.Error("Failed to flush usage counters", "error", err)
+			}
+			if err := s.manager.UpdateQuotaMetrics(ctx); err != nil && !errors.Is(err, storage.ErrDBUnavailable) {
+				slog.Error("Failed to update quota metrics", "error", err)
+			}
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}
+
+// -------------------------------------------------------------------------
+// MULTIPART CLEANUP
+// -------------------------------------------------------------------------
+
+type multipartCleanupService struct {
+	manager *storage.BackendManager
+}
+
+func (s *multipartCleanupService) Run(ctx context.Context) error {
+	ticker := time.NewTicker(1 * time.Hour)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			s.manager.CleanupStaleMultipartUploads(ctx, 24*time.Hour)
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}
+
+// -------------------------------------------------------------------------
+// REBALANCER
+// -------------------------------------------------------------------------
+
+type rebalancerService struct {
+	manager *storage.BackendManager
+}
+
+func (s *rebalancerService) Run(ctx context.Context) error {
+	ticker := time.NewTicker(1 * time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			rcfg := s.manager.RebalanceConfig()
+			if rcfg == nil || !rcfg.Enabled {
+				continue
+			}
+			moved, err := s.manager.Rebalance(ctx, *rcfg)
+			if err != nil && !errors.Is(err, storage.ErrDBUnavailable) {
+				slog.Error("Rebalance failed", "error", err)
+			} else if moved > 0 {
+				slog.Info("Rebalance completed", "objects_moved", moved)
+				if err := s.manager.UpdateQuotaMetrics(ctx); err != nil {
+					slog.Warn("Failed to update quota metrics after rebalance", "error", err)
+				}
+			}
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}
+
+// -------------------------------------------------------------------------
+// REPLICATOR
+// -------------------------------------------------------------------------
+
+type replicatorService struct {
+	manager *storage.BackendManager
+}
+
+func (s *replicatorService) Run(ctx context.Context) error {
+	// Run once at startup to catch up on pending replicas
+	rcfg := s.manager.ReplicationConfig()
+	if rcfg != nil && rcfg.Factor > 1 {
+		created, err := s.manager.Replicate(ctx, *rcfg)
+		if err != nil && !errors.Is(err, storage.ErrDBUnavailable) {
+			slog.Error("Replication startup run failed", "error", err)
+		} else if created > 0 {
+			slog.Info("Replication startup run completed", "copies_created", created)
+			if err := s.manager.UpdateQuotaMetrics(ctx); err != nil {
+				slog.Warn("Failed to update quota metrics after replication startup", "error", err)
+			}
+		}
+	}
+
+	ticker := time.NewTicker(1 * time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			rcfg := s.manager.ReplicationConfig()
+			if rcfg == nil || rcfg.Factor <= 1 {
+				continue
+			}
+			created, err := s.manager.Replicate(ctx, *rcfg)
+			if err != nil && !errors.Is(err, storage.ErrDBUnavailable) {
+				slog.Error("Replication failed", "error", err)
+			} else if created > 0 {
+				slog.Info("Replication completed", "copies_created", created)
+				if err := s.manager.UpdateQuotaMetrics(ctx); err != nil {
+					slog.Warn("Failed to update quota metrics after replication", "error", err)
+				}
+			}
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}

--- a/internal/lifecycle/manager.go
+++ b/internal/lifecycle/manager.go
@@ -1,0 +1,120 @@
+// -------------------------------------------------------------------------------
+// Service Lifecycle Manager
+//
+// Author: Alex Freidah
+//
+// Manages background service goroutines with panic recovery, automatic restart,
+// and ordered shutdown. Services implement the Service interface (blocking Run
+// method); optional Stoppable interface adds explicit cleanup on shutdown.
+// -------------------------------------------------------------------------------
+
+package lifecycle
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// Service represents a long-running background task. Run blocks until ctx is
+// cancelled or a fatal error occurs.
+type Service interface {
+	Run(ctx context.Context) error
+}
+
+// Stoppable is an optional interface for services that need explicit cleanup
+// beyond context cancellation.
+type Stoppable interface {
+	Stop(ctx context.Context) error
+}
+
+type entry struct {
+	name    string
+	service Service
+}
+
+// Manager registers and supervises background services.
+type Manager struct {
+	services []entry
+}
+
+// NewManager creates an empty service manager.
+func NewManager() *Manager {
+	return &Manager{}
+}
+
+// Register adds a named service. Services start in registration order and stop
+// in reverse order.
+func (m *Manager) Register(name string, svc Service) {
+	m.services = append(m.services, entry{name: name, service: svc})
+}
+
+// Run starts all registered services and blocks until ctx is cancelled. Each
+// service runs in its own goroutine with panic recovery and automatic restart.
+func (m *Manager) Run(ctx context.Context) {
+	var wg sync.WaitGroup
+
+	for _, e := range m.services {
+		wg.Add(1)
+		go func(e entry) {
+			defer wg.Done()
+			m.supervise(ctx, e)
+		}(e)
+	}
+
+	wg.Wait()
+}
+
+// Stop calls Stop on services that implement Stoppable, in reverse
+// registration order, bounded by the given timeout.
+func (m *Manager) Stop(timeout time.Duration) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	for i := len(m.services) - 1; i >= 0; i-- {
+		if s, ok := m.services[i].service.(Stoppable); ok {
+			if err := s.Stop(ctx); err != nil {
+				slog.Error("Service stop error",
+					"service", m.services[i].name,
+					"error", err,
+				)
+			}
+		}
+	}
+}
+
+func (m *Manager) supervise(ctx context.Context, e entry) {
+	for {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					slog.Error("Service panicked, restarting",
+						"service", e.name,
+						"panic", fmt.Sprint(r),
+					)
+				}
+			}()
+
+			if err := e.service.Run(ctx); err != nil && ctx.Err() == nil {
+				slog.Error("Service exited unexpectedly, restarting",
+					"service", e.name,
+					"error", err,
+				)
+			}
+		}()
+
+		// If context is done, exit the supervision loop
+		if ctx.Err() != nil {
+			return
+		}
+
+		// Brief pause before restart to avoid tight loops
+		select {
+		case <-time.After(1 * time.Second):
+		case <-ctx.Done():
+			return
+		}
+	}
+}

--- a/internal/lifecycle/manager_test.go
+++ b/internal/lifecycle/manager_test.go
@@ -1,0 +1,197 @@
+package lifecycle
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// -------------------------------------------------------------------------
+// TEST HELPERS
+// -------------------------------------------------------------------------
+
+type counterService struct {
+	count atomic.Int64
+}
+
+func (s *counterService) Run(ctx context.Context) error {
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			s.count.Add(1)
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}
+
+type panicOnceService struct {
+	calls atomic.Int64
+}
+
+func (s *panicOnceService) Run(ctx context.Context) error {
+	n := s.calls.Add(1)
+	if n == 1 {
+		panic("boom")
+	}
+	<-ctx.Done()
+	return nil
+}
+
+type stoppableService struct {
+	stopped chan string
+	name    string
+}
+
+func (s *stoppableService) Run(ctx context.Context) error {
+	<-ctx.Done()
+	return nil
+}
+
+func (s *stoppableService) Stop(_ context.Context) error {
+	s.stopped <- s.name
+	return nil
+}
+
+// -------------------------------------------------------------------------
+// TESTS
+// -------------------------------------------------------------------------
+
+func TestManager_RunAndStop(t *testing.T) {
+	mgr := NewManager()
+	svc := &counterService{}
+	mgr.Register("counter", svc)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		mgr.Run(ctx)
+		close(done)
+	}()
+
+	// Let it tick a few times
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Manager.Run did not return after context cancellation")
+	}
+
+	if n := svc.count.Load(); n == 0 {
+		t.Error("Service never ran")
+	}
+}
+
+func TestManager_PanicRecovery(t *testing.T) {
+	mgr := NewManager()
+	svc := &panicOnceService{}
+	mgr.Register("panic-once", svc)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		mgr.Run(ctx)
+		close(done)
+	}()
+
+	// Wait long enough for the panic + restart + second call
+	time.Sleep(2 * time.Second)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Manager.Run did not return after context cancellation")
+	}
+
+	if n := svc.calls.Load(); n < 2 {
+		t.Errorf("Expected at least 2 calls (panic + restart), got %d", n)
+	}
+}
+
+func TestManager_StopCallsStoppable(t *testing.T) {
+	mgr := NewManager()
+	stopped := make(chan string, 1)
+	svc := &stoppableService{stopped: stopped, name: "svc-a"}
+	mgr.Register("svc-a", svc)
+
+	// Also register a non-stoppable to verify it's skipped
+	mgr.Register("counter", &counterService{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		mgr.Run(ctx)
+		close(done)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	mgr.Stop(5 * time.Second)
+
+	select {
+	case name := <-stopped:
+		if name != "svc-a" {
+			t.Errorf("Expected stop for svc-a, got %s", name)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop was never called on stoppable service")
+	}
+}
+
+func TestManager_StopReverseOrder(t *testing.T) {
+	mgr := NewManager()
+	var mu sync.Mutex
+	var order []string
+	stopped := make(chan string, 3)
+
+	for _, name := range []string{"first", "second", "third"} {
+		svc := &stoppableService{stopped: stopped, name: name}
+		mgr.Register(name, svc)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		mgr.Run(ctx)
+		close(done)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	// Stop collects in reverse registration order (synchronous per service)
+	go func() {
+		mgr.Stop(5 * time.Second)
+	}()
+
+	for range 3 {
+		select {
+		case name := <-stopped:
+			mu.Lock()
+			order = append(order, name)
+			mu.Unlock()
+		case <-time.After(2 * time.Second):
+			t.Fatal("Timed out waiting for Stop calls")
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	expected := []string{"third", "second", "first"}
+	for i, name := range expected {
+		if i >= len(order) || order[i] != name {
+			t.Errorf("Expected stop order %v, got %v", expected, order)
+			break
+		}
+	}
+}


### PR DESCRIPTION
Extract the four inline background goroutines (usage flush, multipart cleanup, rebalancer, replicator) into typed services managed by a new lifecycle.Manager. The manager supervises each service with panic recovery, automatic restart after 1s pause, and reverse-order shutdown. Previously silent UpdateQuotaMetrics errors after rebalance/replication are now logged.