### PR TITLE
feat: add structured audit logging with request ID tracing

### DIFF
--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,0 +1,423 @@
+# S3 Orchestrator Coding Style Guide
+
+**Author:** Alex Freidah
+
+---
+
+## Table of Contents
+
+- [Core Principles](#core-principles)
+- [Comment Types and Spacing](#comment-types-and-spacing)
+- [File Headers](#file-headers)
+- [Go Conventions](#go-conventions)
+- [Error Handling](#error-handling)
+- [Logging and Audit](#logging-and-audit)
+- [Testing](#testing)
+- [Code Style](#code-style)
+
+---
+
+## Core Principles
+
+- **ASCII-only characters** - Never use Unicode em-dashes, en-dashes, or box-drawing characters
+- **Dashes, not equals** - Always use `-` for dividers, never `=`
+- **Box comment spacing** - ALL box comments (79-char file headers and 73-char sections) ALWAYS have a blank line after
+- **Professional tone** - No personal references, no numbered lists, no casual language
+- **Self-documenting** - Code explains *why*, not just *what*
+- **Streaming over buffering** - Use `io.Pipe` and streaming patterns for object data; never buffer entire objects in memory
+- **Context propagation** - Pass `context.Context` through all function chains for cancellation, tracing, and audit correlation
+
+---
+
+## Comment Types and Spacing
+
+### File Header (79 characters)
+
+**Format:**
+```go
+// -------------------------------------------------------------------------------
+// Title of File or Component
+//
+// Author: Alex Freidah
+//
+// 2-4 sentence description of the file's purpose, scope, and key functionality.
+// Include architecture notes, design decisions, or important context that helps
+// readers understand the overall purpose.
+// -------------------------------------------------------------------------------
+
+package mypackage
+```
+
+**Spacing Rules:**
+- Blank line after title
+- Blank line after metadata
+- Blank line before closing divider
+- **Blank line after closing divider** - always separate box from code
+
+### Major Section Box (73 characters)
+
+**Format:**
+```go
+// -------------------------------------------------------------------------
+// SECTION NAME
+// -------------------------------------------------------------------------
+
+func doSomething() {
+    // ...
+}
+```
+
+**Spacing Rules:**
+- Use ALL CAPS for section name
+- **Blank line AFTER closing divider** - separates section from code
+- Used for major logical divisions (e.g., PUBLIC API, INTERNALS, TYPES)
+
+### Single-Line Comments
+
+Standard Go comments placed directly above the code they describe:
+
+```go
+// Parse request path
+bucket, key, ok := parsePath(r.URL.Path)
+if !ok {
+    return errInvalidPath
+}
+```
+
+- **NO blank line before code** - placed directly above the block
+- Use lowercase or sentence case
+- Used for minor divisions or labels within functions
+
+### Inline Comments
+
+```go
+m.usage.Record(backendName, 2, movedSize, 0) // Get + Delete, egress
+```
+
+- Use sparingly
+- Explain *why*, not *what*
+- Keep concise (< 50 characters)
+
+---
+
+## Comment Type Decision Tree
+
+```
+Is this a file header?
+  YES -> Use 79-char divider, blank line AFTER
+
+Is this a major section (types, public API, internals)?
+  YES -> Use 73-char box, blank line AFTER
+
+Is this a minor division or label within a function?
+  YES -> Use a standard single-line comment, NO blank line before code
+
+Is this explaining a specific line?
+  YES -> Use inline comment
+```
+
+**Key Rule:** ALL box comments (79-char and 73-char) have a blank line after. Single-line comments have no extra spacing.
+
+---
+
+## File Headers
+
+Every `.go` file starts with a 79-char header block:
+
+```go
+// -------------------------------------------------------------------------------
+// Object Operations - PUT, GET, HEAD, DELETE, COPY
+//
+// Author: Alex Freidah
+//
+// Object-level CRUD operations on the BackendManager. Handles backend selection
+// via routing strategy, read failover across replicas, broadcast reads during
+// degraded mode, and usage limit enforcement on reads and writes.
+// -------------------------------------------------------------------------------
+
+package storage
+```
+
+**Rules:**
+- Use `//` comments (not `/* */` blocks)
+- Title line describes the file's scope, not the package
+- Description covers purpose, key behaviors, and dependencies
+- The `package` declaration follows immediately after the closing divider + blank line
+
+---
+
+## Go Conventions
+
+### Indentation
+
+- **1 tab** - Go standard (`gofmt` enforced)
+
+### Imports
+
+Group imports in three blocks separated by blank lines:
+
+```go
+import (
+    "context"
+    "fmt"
+    "time"
+
+    "github.com/afreidah/s3-orchestrator/internal/audit"
+    "github.com/afreidah/s3-orchestrator/internal/telemetry"
+
+    "go.opentelemetry.io/otel/attribute"
+    "github.com/prometheus/client_golang/prometheus"
+)
+```
+
+Order: stdlib, internal packages, external packages.
+
+### Naming
+
+- **Exported types** get standard Go doc comments placed directly above the declaration
+- **Constants** grouped by concern with `const` blocks, named in `CamelCase`
+- **Sentinel errors** use `Err` prefix: `ErrObjectNotFound`, `ErrDBUnavailable`
+- **S3Error type** wraps HTTP status + S3 error code for typed error responses
+- **Operation names** are consistent PascalCase strings matching S3 API names: `"PutObject"`, `"GetObject"`, `"CreateMultipartUpload"`
+
+### Struct Organization
+
+Group related fields with inline comments explaining non-obvious fields:
+
+```go
+type BackendManager struct {
+    backends        map[string]ObjectBackend
+    store           MetadataStore
+    order           []string
+    cache           *LocationCache
+    backendTimeout  time.Duration
+    usage           *UsageTracker
+    metrics         *MetricsCollector
+    dashboard       *DashboardAggregator
+    routingStrategy string
+    rebalanceCfg    atomic.Pointer[config.RebalanceConfig]
+    replicationCfg  atomic.Pointer[config.ReplicationConfig]
+}
+```
+
+### Concurrency Patterns
+
+- **Atomic pointers** for hot-reloadable config (`atomic.Pointer[T]`)
+- **Atomic counters** for usage tracking, flushed periodically to the database
+- **Context-scoped timeouts** via helper methods (`m.withTimeout(ctx)`) for backend calls
+- **Graceful shutdown** via `context.WithCancel` + signal handling
+
+---
+
+## Error Handling
+
+### S3 Errors
+
+Use the `S3Error` type for errors that map to S3 HTTP responses:
+
+```go
+var ErrObjectNotFound = &S3Error{
+    StatusCode: 404,
+    Code:       "NoSuchKey",
+    Message:    "The specified key does not exist",
+}
+```
+
+Handlers use `writeStorageError` to convert `S3Error` instances into XML responses. Untyped errors fall back to `502 InternalError`.
+
+### Error Classification
+
+The `classifyWriteError` helper distinguishes database unavailability (circuit breaker open) from other failures, returning appropriate S3 error codes:
+
+- `ErrDBUnavailable` -> `503 ServiceUnavailable`
+- Other errors -> `502 InternalError`
+
+### Background Operation Errors
+
+Background workers (rebalancer, replicator, cleanup) log errors and continue rather than crashing. Individual item failures are logged with `slog.Warn` and skipped; the batch proceeds with remaining items.
+
+---
+
+## Logging and Audit
+
+### Structured Logging
+
+All logging uses `log/slog` with JSON output to stdout. The logger is initialized in `main.go`:
+
+```go
+slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+    Level: slog.LevelInfo,
+})))
+```
+
+### Audit Logging
+
+The `internal/audit` package provides structured audit entries for security-relevant operations. Audit entries are distinguished by the `"audit": true` field.
+
+**S3 API requests** produce two correlated audit entries sharing the same `request_id`:
+
+- HTTP layer (`s3.PutObject`, `s3.GetObject`, etc.) - method, path, bucket, status, duration
+- Storage layer (`storage.PutObject`, `storage.GetObject`, etc.) - key, backend, size
+
+**Internal operations** generate their own correlation IDs:
+
+```go
+ctx = audit.WithRequestID(ctx, audit.NewID())
+audit.Log(ctx, "rebalance.start",
+    slog.String("strategy", cfg.Strategy),
+    slog.Int("batch_size", cfg.BatchSize),
+)
+```
+
+**Rules:**
+- Use `audit.Log` for operations that change state or serve data (not for debug/health checks)
+- Always pass context so the request ID propagates
+- Event names use dotted notation: `"s3.PutObject"`, `"storage.DeleteObject"`, `"rebalance.move"`
+- Include enough attributes to reconstruct the operation without reading other log lines
+
+### Request ID Propagation
+
+Request IDs flow through context via `audit.WithRequestID` / `audit.RequestID`:
+
+- S3 API requests: extracted from `X-Request-Id` header or generated, set on context before auth
+- Internal operations: generated at the start of each background task tick or batch run
+- The ID is also set as a `s3proxy.request_id` attribute on OpenTelemetry spans
+
+### Log Levels
+
+| Level | Use |
+|-------|-----|
+| `slog.Info` | Startup, shutdown, config reload, audit entries |
+| `slog.Warn` | Recoverable failures (failover to replica, orphan cleanup, non-critical background errors) |
+| `slog.Error` | Unrecoverable failures (startup errors, DB connection loss, background task crashes) |
+
+---
+
+## Testing
+
+### Unit Tests
+
+- Test files live alongside the code they test: `server_test.go`, `manager_objects_test.go`
+- Use table-driven tests for operations with multiple input/output combinations
+- Mock interfaces (`MetadataStore`, `ObjectBackend`) live in `internal/testutil/`
+- Test names follow `TestFunctionName_Scenario` convention
+
+### Integration Tests
+
+- Located in `internal/integration/`
+- Gated behind the `integration` build tag
+- Run in-process with real MinIO and PostgreSQL containers
+- Cover end-to-end flows: CRUD, quota enforcement, multipart, replication, circuit breaker
+
+### Test Patterns
+
+- **Mock stores** implement the full `MetadataStore` interface with configurable responses
+- **FailableStore** wraps a mock to inject errors for circuit breaker testing
+- Test assertions use standard `testing.T` methods, not external assertion libraries
+
+---
+
+## Code Style
+
+### Character Rules
+
+**ALWAYS USE:**
+- ASCII dash: `-` (hyphen-minus, U+002D)
+- Standard ASCII characters only
+
+**NEVER USE:**
+- Unicode em-dash (U+2014)
+- Unicode en-dash (U+2013)
+- Unicode box-drawing (U+2500)
+- Equals signs for dividers
+
+### Professional Tone
+
+Avoid:
+- Personal references: "Let me show you...", "We need to..."
+- Numbered lists in comments: "1. First do this", "2. Then do that"
+- Conversational tone: "Now we're going to..."
+- Future tense: "This will create...", "We'll configure..."
+
+Use:
+- Present tense: "Creates", "Configures", "Manages"
+- Declarative statements: "Service runs on port 9000"
+- Technical precision: "Uses SigV4 for request authentication"
+- Impersonal voice: "The manager selects...", "The circuit breaker wraps..."
+
+---
+
+## Quick Reference
+
+| Comment Type | Length | Spacing After | Use Case |
+|-------------|--------|---------------|----------|
+| File header | 79 chars | 1 blank line | Top of every `.go` file |
+| Major section | 73 chars | 1 blank line | Major divisions (types, API, internals) |
+| Single-line comment | Variable | None | Minor divisions within functions |
+| Inline | Brief | N/A | Specific line explanation |
+
+---
+
+## Examples
+
+### Good
+
+```go
+// -------------------------------------------------------------------------------
+// Replicator - Background Replica Creation Worker
+//
+// Author: Alex Freidah
+//
+// Creates additional copies of under-replicated objects across backends. Objects
+// are written to one backend on PUT; this worker asynchronously ensures each
+// object reaches the configured replication factor. Uses conditional DB inserts
+// to safely handle concurrent overwrites and deletes.
+// -------------------------------------------------------------------------------
+
+package storage
+
+// -------------------------------------------------------------------------
+// PUBLIC API
+// -------------------------------------------------------------------------
+
+// Replicate finds under-replicated objects and creates additional copies to
+// reach the target replication factor. Returns the number of copies created.
+func (m *BackendManager) Replicate(ctx context.Context, cfg config.ReplicationConfig) (int, error) {
+    start := time.Now()
+    ctx = audit.WithRequestID(ctx, audit.NewID())
+
+    // Find under-replicated objects
+    locations, err := m.store.GetUnderReplicatedObjects(ctx, cfg.Factor, cfg.BatchSize)
+    if err != nil {
+        return 0, fmt.Errorf("failed to query under-replicated objects: %w", err)
+    }
+    // ...
+}
+```
+
+### Bad
+
+```go
+// ==================================
+// Replicator
+//
+// This module will handle replication for the user.
+// Here's how it works:
+// 1. First we find objects that need replication
+// 2. Then we copy them to other backends
+// 3. Finally we record the results
+// ==================================
+
+package storage
+
+// Let's create the replicate function
+func (m *BackendManager) Replicate(ctx context.Context, cfg config.ReplicationConfig) (int, error) {
+    // get the start time
+    start := time.Now()
+    // ...
+}
+```
+
+---
+
+**Remember:** Comments should explain *why* decisions were made, not *what* the code does. The code itself should be clear enough to understand *what* it does.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -316,6 +316,22 @@ _, err := client.DeleteObject(context.Background(), &s3.DeleteObjectInput{
 })
 ```
 
+## Request Tracing
+
+Every response from the orchestrator includes an `X-Amz-Request-Id` header with a unique ID for that request. When reporting issues to your admin, include this ID so they can look up the full request trace in the audit logs.
+
+You can also supply your own correlation ID by sending an `X-Request-Id` header with your request. The orchestrator will use your ID instead of generating one and return it in the response.
+
+```bash
+# Check the request ID in a response
+s3o s3api put-object --bucket app1-files --key test.txt --body test.txt 2>&1 | grep -i request-id
+
+# Supply your own correlation ID
+curl -H "X-Request-Id: my-trace-123" \
+     http://s3-orchestrator.service.consul:9000/app1-files/test.txt
+# Response header: X-Amz-Request-Id: my-trace-123
+```
+
 ## Limitations
 
 The orchestrator implements a practical subset of the S3 API. A few things to be aware of:

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -1,0 +1,90 @@
+// -------------------------------------------------------------------------------
+// Audit - Request ID Tracing and Structured Audit Logging
+//
+// Author: Alex Freidah
+//
+// Context-based request ID propagation and structured audit logging. Generates
+// unique request IDs for S3 API requests (honoring client-provided X-Request-Id)
+// and correlation IDs for internal operations. Emits structured slog entries
+// with an "audit" marker for log pipeline filtering.
+// -------------------------------------------------------------------------------
+
+package audit
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"log/slog"
+	"time"
+
+	"github.com/afreidah/s3-orchestrator/internal/telemetry"
+)
+
+// -------------------------------------------------------------------------
+// CONTEXT KEYS
+// -------------------------------------------------------------------------
+
+type contextKey int
+
+const (
+	requestIDKey contextKey = iota
+)
+
+// -------------------------------------------------------------------------
+// REQUEST ID
+// -------------------------------------------------------------------------
+
+// NewID generates a hex-encoded 16-byte random ID suitable for request
+// correlation. Falls back to a timestamp-based ID if crypto/rand fails.
+func NewID() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		// Fallback: should never happen with a healthy OS
+		return hex.EncodeToString([]byte(time.Now().Format("20060102150405.000000000")))
+	}
+	return hex.EncodeToString(b)
+}
+
+// WithRequestID stores a request ID in the context.
+func WithRequestID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, requestIDKey, id)
+}
+
+// RequestID extracts the request ID from the context. Returns empty string
+// if no request ID is set.
+func RequestID(ctx context.Context) string {
+	if id, ok := ctx.Value(requestIDKey).(string); ok {
+		return id
+	}
+	return ""
+}
+
+// -------------------------------------------------------------------------
+// AUDIT LOGGING
+// -------------------------------------------------------------------------
+
+// Log emits a structured audit log entry at Info level. Automatically
+// includes the request ID from context and increments the audit event
+// counter.
+func Log(ctx context.Context, event string, attrs ...slog.Attr) {
+	telemetry.AuditEventsTotal.WithLabelValues(event).Inc()
+
+	base := []slog.Attr{
+		slog.Bool("audit", true),
+		slog.String("event", event),
+	}
+
+	if id := RequestID(ctx); id != "" {
+		base = append(base, slog.String("request_id", id))
+	}
+
+	base = append(base, attrs...)
+
+	args := make([]any, len(base))
+	for i, a := range base {
+		args[i] = a
+	}
+
+	slog.LogAttrs(ctx, slog.LevelInfo, "audit", base...)
+}

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -1,0 +1,104 @@
+package audit
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+)
+
+func TestNewID_UniqueAndCorrectLength(t *testing.T) {
+	ids := make(map[string]bool, 100)
+	for i := 0; i < 100; i++ {
+		id := NewID()
+		if len(id) != 32 { // 16 bytes hex-encoded = 32 chars
+			t.Fatalf("expected 32-char ID, got %d: %q", len(id), id)
+		}
+		if ids[id] {
+			t.Fatalf("duplicate ID generated: %q", id)
+		}
+		ids[id] = true
+	}
+}
+
+func TestContextRoundTrip(t *testing.T) {
+	ctx := context.Background()
+
+	// Empty context returns empty string
+	if got := RequestID(ctx); got != "" {
+		t.Fatalf("expected empty string from bare context, got %q", got)
+	}
+
+	// Round-trip
+	ctx = WithRequestID(ctx, "test-id-123")
+	if got := RequestID(ctx); got != "test-id-123" {
+		t.Fatalf("expected test-id-123, got %q", got)
+	}
+
+	// Override
+	ctx = WithRequestID(ctx, "override-456")
+	if got := RequestID(ctx); got != "override-456" {
+		t.Fatalf("expected override-456, got %q", got)
+	}
+}
+
+func TestLog_StructuredOutput(t *testing.T) {
+	var buf bytes.Buffer
+	handler := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})
+	slog.SetDefault(slog.New(handler))
+	defer slog.SetDefault(slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)))
+
+	ctx := WithRequestID(context.Background(), "req-abc")
+	Log(ctx, "s3.PutObject",
+		slog.String("key", "photos/cat.jpg"),
+		slog.Int64("size", 12345),
+	)
+
+	var entry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("failed to parse log output: %v\nraw: %s", err, buf.String())
+	}
+
+	// Verify required fields
+	if entry["audit"] != true {
+		t.Errorf("expected audit=true, got %v", entry["audit"])
+	}
+	if entry["event"] != "s3.PutObject" {
+		t.Errorf("expected event=s3.PutObject, got %v", entry["event"])
+	}
+	if entry["request_id"] != "req-abc" {
+		t.Errorf("expected request_id=req-abc, got %v", entry["request_id"])
+	}
+	if entry["key"] != "photos/cat.jpg" {
+		t.Errorf("expected key=photos/cat.jpg, got %v", entry["key"])
+	}
+	if size, ok := entry["size"].(float64); !ok || int64(size) != 12345 {
+		t.Errorf("expected size=12345, got %v", entry["size"])
+	}
+}
+
+func TestLog_WithoutRequestID(t *testing.T) {
+	var buf bytes.Buffer
+	handler := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})
+	slog.SetDefault(slog.New(handler))
+	defer slog.SetDefault(slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)))
+
+	Log(context.Background(), "rebalance.start")
+
+	var entry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("failed to parse log output: %v", err)
+	}
+
+	if entry["audit"] != true {
+		t.Errorf("expected audit=true")
+	}
+	if entry["event"] != "rebalance.start" {
+		t.Errorf("expected event=rebalance.start, got %v", entry["event"])
+	}
+	// request_id should not be present
+	if _, ok := entry["request_id"]; ok {
+		t.Errorf("expected no request_id field, but got %v", entry["request_id"])
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -20,6 +20,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/afreidah/s3-orchestrator/internal/audit"
 	"github.com/afreidah/s3-orchestrator/internal/auth"
 	"github.com/afreidah/s3-orchestrator/internal/storage"
 	"github.com/afreidah/s3-orchestrator/internal/telemetry"
@@ -54,6 +55,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
 	method := r.Method
 
+	// --- Generate or adopt request ID ---
+	requestID := r.Header.Get("X-Request-Id")
+	if requestID == "" {
+		requestID = audit.NewID()
+	}
+	ctx := audit.WithRequestID(r.Context(), requestID)
+	w.Header().Set("X-Amz-Request-Id", requestID)
+
 	// --- Track inflight requests ---
 	telemetry.InflightRequests.WithLabelValues(method).Inc()
 	defer telemetry.InflightRequests.WithLabelValues(method).Dec()
@@ -62,7 +71,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	authorizedBucket, err := s.GetBucketAuth().AuthenticateAndResolveBucket(r)
 	if err != nil {
 		s.recordRequest(method, http.StatusForbidden, start, 0, 0)
-		slog.Warn("Auth failed", "method", method, "path", r.URL.Path, "remote", r.RemoteAddr, "error", err)
+		audit.Log(ctx, "s3.AuthFailure",
+			slog.String("method", method),
+			slog.String("path", r.URL.Path),
+			slog.String("remote", r.RemoteAddr),
+			slog.String("error", err.Error()),
+			slog.Int("status", http.StatusForbidden),
+			slog.Duration("duration", time.Since(start)),
+		)
 		writeS3Error(w, http.StatusForbidden, "AccessDenied", "Access denied")
 		return
 	}
@@ -71,7 +87,13 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	bucket, key, ok := parsePath(r.URL.Path)
 	if !ok {
 		s.recordRequest(method, http.StatusBadRequest, start, 0, 0)
-		slog.Warn("Invalid path", "method", method, "path", r.URL.Path, "remote", r.RemoteAddr)
+		audit.Log(ctx, "s3.InvalidPath",
+			slog.String("method", method),
+			slog.String("path", r.URL.Path),
+			slog.String("remote", r.RemoteAddr),
+			slog.Int("status", http.StatusBadRequest),
+			slog.Duration("duration", time.Since(start)),
+		)
 		writeS3Error(w, http.StatusBadRequest, "InvalidRequest", "Invalid path format")
 		return
 	}
@@ -79,8 +101,15 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// --- Verify path bucket matches authorized bucket ---
 	if bucket != authorizedBucket {
 		s.recordRequest(method, http.StatusForbidden, start, 0, 0)
-		slog.Warn("Bucket mismatch", "method", method, "path", r.URL.Path, "remote", r.RemoteAddr,
-			"authorized_bucket", authorizedBucket, "requested_bucket", bucket)
+		audit.Log(ctx, "s3.BucketMismatch",
+			slog.String("method", method),
+			slog.String("path", r.URL.Path),
+			slog.String("remote", r.RemoteAddr),
+			slog.String("authorized_bucket", authorizedBucket),
+			slog.String("requested_bucket", bucket),
+			slog.Int("status", http.StatusForbidden),
+			slog.Duration("duration", time.Since(start)),
+		)
 		writeS3Error(w, http.StatusForbidden, "AccessDenied", "Access denied")
 		return
 	}
@@ -89,23 +118,34 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	internalKey := bucket + "/" + key
 
 	// --- Start tracing span ---
-	ctx, span := telemetry.StartSpan(r.Context(), fmt.Sprintf("HTTP %s", method),
-		telemetry.RequestAttributes(method, r.URL.Path, bucket, key, r.RemoteAddr)...,
+	ctx, span := telemetry.StartSpan(ctx, fmt.Sprintf("HTTP %s", method),
+		append(telemetry.RequestAttributes(method, r.URL.Path, bucket, key, r.RemoteAddr),
+			telemetry.AttrRequestID.String(requestID))...,
 	)
 	defer span.End()
 
-	// --- Route by method ---
+	// --- Route by method and track operation name ---
 	var status int
 	var requestSize, responseSize int64
+	var operation string
 
 	// --- Bucket-level operations (no key) ---
 	if key == "" {
 		if method != http.MethodGet {
 			s.recordRequest(method, http.StatusMethodNotAllowed, start, 0, 0)
+			audit.Log(ctx, "s3.MethodNotAllowed",
+				slog.String("method", method),
+				slog.String("path", r.URL.Path),
+				slog.String("remote", r.RemoteAddr),
+				slog.String("bucket", bucket),
+				slog.Int("status", http.StatusMethodNotAllowed),
+				slog.Duration("duration", time.Since(start)),
+			)
 			writeS3Error(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "Method not supported for bucket")
 			span.SetStatus(codes.Error, "method not allowed for bucket")
 			return
 		}
+		operation = "ListObjectsV2"
 		status, err = s.handleListObjectsV2(ctx, w, r, bucket)
 	} else {
 		// --- Multipart upload routing ---
@@ -115,20 +155,33 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		switch {
 		case hasUploads && method == http.MethodPost:
+			operation = "CreateMultipartUpload"
 			status, err = s.handleCreateMultipartUpload(ctx, w, r, bucket, key, internalKey)
 		case uploadID != "":
 			switch method {
 			case http.MethodPut:
+				operation = "UploadPart"
 				requestSize = r.ContentLength
 				status, err = s.handleUploadPart(ctx, w, r, internalKey)
 			case http.MethodPost:
+				operation = "CompleteMultipartUpload"
 				status, err = s.handleCompleteMultipartUpload(ctx, w, r, bucket, key)
 			case http.MethodDelete:
+				operation = "AbortMultipartUpload"
 				status, err = s.handleAbortMultipartUpload(ctx, w, uploadID)
 			case http.MethodGet:
+				operation = "ListParts"
 				status, err = s.handleListParts(ctx, w, r, bucket, key, internalKey)
 			default:
 				s.recordRequest(method, http.StatusMethodNotAllowed, start, 0, 0)
+				audit.Log(ctx, "s3.MethodNotAllowed",
+					slog.String("method", method),
+					slog.String("path", r.URL.Path),
+					slog.String("remote", r.RemoteAddr),
+					slog.String("bucket", bucket),
+					slog.Int("status", http.StatusMethodNotAllowed),
+					slog.Duration("duration", time.Since(start)),
+				)
 				writeS3Error(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "Method not supported")
 				span.SetStatus(codes.Error, "method not allowed")
 				return
@@ -137,20 +190,32 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			switch method {
 			case http.MethodPut:
 				if copySource := r.Header.Get("X-Amz-Copy-Source"); copySource != "" {
+					operation = "CopyObject"
 					status, err = s.handleCopyObject(ctx, w, r, bucket, internalKey, copySource)
 				} else {
+					operation = "PutObject"
 					requestSize = r.ContentLength
 					status, err = s.handlePut(ctx, w, r, internalKey)
 				}
 			case http.MethodGet:
+				operation = "GetObject"
 				status, responseSize, err = s.handleGet(ctx, w, r, internalKey)
 			case http.MethodHead:
+				operation = "HeadObject"
 				status, err = s.handleHead(ctx, w, r, internalKey)
 			case http.MethodDelete:
+				operation = "DeleteObject"
 				status, err = s.handleDelete(ctx, w, r, internalKey)
 			default:
 				s.recordRequest(method, http.StatusMethodNotAllowed, start, 0, 0)
-				slog.Warn("Method not allowed", "method", method, "path", r.URL.Path, "remote", r.RemoteAddr)
+				audit.Log(ctx, "s3.MethodNotAllowed",
+					slog.String("method", method),
+					slog.String("path", r.URL.Path),
+					slog.String("remote", r.RemoteAddr),
+					slog.String("bucket", bucket),
+					slog.Int("status", http.StatusMethodNotAllowed),
+					slog.Duration("duration", time.Since(start)),
+				)
 				writeS3Error(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "Method not supported")
 				span.SetStatus(codes.Error, "method not allowed")
 				return
@@ -168,14 +233,30 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	span.SetAttributes(attribute.Int("http.status_code", status))
 
-	// --- Log request ---
+	// --- Audit log ---
 	elapsed := time.Since(start)
-	logAttrs := []any{"method", method, "path", r.URL.Path, "remote", r.RemoteAddr, "bucket", bucket, "status", status, "duration", elapsed}
-	if err != nil {
-		slog.Error("Request failed", append(logAttrs, "error", err)...)
-	} else {
-		slog.Info("Request completed", logAttrs...)
+	auditAttrs := []slog.Attr{
+		slog.String("operation", operation),
+		slog.String("method", method),
+		slog.String("path", r.URL.Path),
+		slog.String("remote", r.RemoteAddr),
+		slog.String("bucket", bucket),
+		slog.Int("status", status),
+		slog.Duration("duration", elapsed),
 	}
+	if key != "" {
+		auditAttrs = append(auditAttrs, slog.String("key", key))
+	}
+	if requestSize > 0 {
+		auditAttrs = append(auditAttrs, slog.Int64("request_size", requestSize))
+	}
+	if responseSize > 0 {
+		auditAttrs = append(auditAttrs, slog.Int64("response_size", responseSize))
+	}
+	if err != nil {
+		auditAttrs = append(auditAttrs, slog.String("error", err.Error()))
+	}
+	audit.Log(ctx, "s3."+operation, auditAttrs...)
 }
 
 // recordRequest updates Prometheus metrics for a completed request.

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -351,6 +351,17 @@ var (
 		[]string{"operation"},
 	)
 
+	// --- Audit metrics ---
+
+	// AuditEventsTotal counts audit log entries by event type.
+	AuditEventsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "s3proxy_audit_events_total",
+			Help: "Total number of audit log entries emitted",
+		},
+		[]string{"event"},
+	)
+
 	// --- Info metric ---
 
 	// BuildInfo exposes version information.

--- a/internal/telemetry/tracing.go
+++ b/internal/telemetry/tracing.go
@@ -124,6 +124,7 @@ func StartSpan(ctx context.Context, name string, attrs ...attribute.KeyValue) (c
 
 // S3 proxy specific attribute keys.
 var (
+	AttrRequestID       = attribute.Key("s3proxy.request_id")
 	AttrVirtualBucket   = attribute.Key("s3proxy.bucket.virtual")
 	AttrBackendBucket   = attribute.Key("s3proxy.bucket.backend")
 	AttrObjectKey       = attribute.Key("s3proxy.key")


### PR DESCRIPTION
  Introduces the internal/audit package for context-based request ID
  propagation and structured audit log entries marked with audit: true.
  Every S3 API request gets a unique ID (or honors the client-supplied
  X-Request-Id header), returned via X-Amz-Request-Id and propagated
  through context to produce correlated HTTP-level and storage-level
  audit entries. Background operations (rebalance, replication, multipart
  cleanup, usage flush) generate their own correlation IDs per tick.
  Adds s3proxy_audit_events_total Prometheus counter and s3proxy.request_id
  span attribute for cross-referencing logs and traces. Updates docs and
  version references to v0.6.0.