### PR TITLE
feat: add Debian packaging with nfpm and systemd service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,24 @@ jobs:
       - name: Cleanup
         if: always()
         run: make integration-clean
+
+  package:
+    runs-on: ubuntu-latest
+    needs: [lint, test]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install nfpm and lintian
+        run: |
+          go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
+          sudo apt-get update && sudo apt-get install -y lintian
+
+      - name: Build and lint deb (amd64)
+        run: make deb-lint DEB_ARCH=amd64
+
+      - name: Build deb (arm64)
+        run: make deb DEB_ARCH=arm64

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /s3-orchestrator
 config.yaml
 *.test
+dist/
+*.deb
+packaging/changelog.gz

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 # -------------------------------------------------------------------------------
-# S3 Orchestrator - Multi-Architecture Build and Push
+# S3 Orchestrator - Build, Package, and Push
 #
 # Author: Alex Freidah
 #
 # Go S3 orchestrator for unified S3-compatible storage access. Builds multi-arch
-# container images.
+# container images and Debian packages.
 # -------------------------------------------------------------------------------
 
 REGISTRY   ?= registry.munchbox.cc
@@ -14,6 +14,14 @@ VERSION    ?= latest
 FULL_TAG   := $(REGISTRY)/$(IMAGE):$(VERSION)
 CACHE_TAG  := $(REGISTRY)/$(IMAGE):cache
 PLATFORMS  := linux/amd64,linux/arm64
+
+# --- Go build flags ---
+GO_LDFLAGS := -s -w -X github.com/afreidah/s3-orchestrator/internal/telemetry.Version=$(VERSION)
+
+# --- Debian packaging ---
+DEB_VERSION ?= $(shell v="$(VERSION)"; if echo "$$v" | grep -qE '^[0-9]'; then echo "$$v"; else echo "0.0.0+$$v"; fi)
+DEB_ARCH    ?= $(shell dpkg --print-architecture 2>/dev/null || echo amd64)
+DEB_OUT      = s3-orchestrator_$(DEB_VERSION)_$(DEB_ARCH).deb
 
 # -------------------------------------------------------------------------
 # DEFAULT TARGET
@@ -100,12 +108,48 @@ integration-clean: ## Stop and remove integration test containers
 	docker compose -f $(COMPOSE_FILE) down -v
 
 # -------------------------------------------------------------------------
+# TOOL INSTALLATION
+# -------------------------------------------------------------------------
+
+tools: ## Install build and packaging dependencies
+	go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest
+	go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
+	sudo apt-get update && sudo apt-get install -y lintian
+
+# -------------------------------------------------------------------------
+# DEBIAN PACKAGING
+# -------------------------------------------------------------------------
+
+# --- Map dpkg architecture names to GOARCH ---
+GOARCH_amd64 := amd64
+GOARCH_arm64 := arm64
+GOARCH       := $(GOARCH_$(DEB_ARCH))
+
+prep-changelog: ## Compress changelog for Debian packaging
+	@gzip -9 -n -c packaging/changelog > packaging/changelog.gz
+
+deb: prep-changelog ## Build a .deb package for DEB_ARCH (default: host arch)
+	mkdir -p dist
+	CGO_ENABLED=0 GOOS=linux GOARCH=$(GOARCH) go build \
+	  -ldflags="$(GO_LDFLAGS)" \
+	  -o dist/s3-orchestrator ./cmd/s3-orchestrator
+	VERSION=$(DEB_VERSION) GOARCH=$(GOARCH) nfpm package --packager deb --target $(DEB_OUT)
+
+deb-lint: deb ## Run lintian on the .deb package
+	lintian --tag-display-limit 0 $(DEB_OUT)
+
+deb-all: ## Build .deb packages for amd64 and arm64
+	$(MAKE) deb DEB_ARCH=amd64
+	$(MAKE) deb DEB_ARCH=arm64
+
+# -------------------------------------------------------------------------
 # CLEANUP
 # -------------------------------------------------------------------------
 
 clean: ## Remove build artifacts and local image
 	go clean
+	rm -rf dist/ *.deb packaging/changelog.gz
 	docker rmi $(FULL_TAG) || true
 
-.PHONY: help builder build push generate test vet lint run integration-deps integration-test integration-clean clean
+.PHONY: help builder build push generate test vet lint run integration-deps integration-test integration-clean tools prep-changelog deb deb-lint deb-all clean
 .DEFAULT_GOAL := help

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -1,0 +1,99 @@
+# -------------------------------------------------------------------------------
+# nfpm Configuration - Debian Package Build
+#
+# Author: Alex Freidah
+#
+# Defines package metadata and contents for building .deb packages via nfpm.
+# Includes systemd service, sample config, default env file, and maintainer
+# scripts for user creation and cleanup.
+# -------------------------------------------------------------------------------
+
+name: s3-orchestrator
+arch: ${GOARCH}
+platform: linux
+version: ${VERSION}
+release: 1
+section: admin
+priority: optional
+maintainer: Alex Freidah <alex.freidah@gmail.com>
+description: |
+  Unified S3-compatible storage endpoint. Routes requests across multiple
+  S3 backends with quota management, replication, and usage tracking.
+vendor: Munchbox
+homepage: https://github.com/afreidah/s3-orchestrator
+
+# -------------------------------------------------------------------------
+# PACKAGE CONTENTS
+# -------------------------------------------------------------------------
+
+contents:
+  # --- Binary ---
+  - src: ./dist/s3-orchestrator
+    dst: /usr/bin/s3-orchestrator
+    file_info:
+      mode: 0755
+
+  # --- Systemd unit ---
+  - src: ./packaging/s3-orchestrator.service
+    dst: /usr/lib/systemd/system/s3-orchestrator.service
+    file_info:
+      mode: 0644
+
+  # --- Default environment file ---
+  - src: ./packaging/s3-orchestrator.default
+    dst: /etc/default/s3-orchestrator
+    type: config|noreplace
+    file_info:
+      mode: 0640
+
+  # --- Config directory ---
+  - dst: /etc/s3-orchestrator
+    type: dir
+    file_info:
+      mode: 0750
+
+  # --- Sample config (marked as conffile, preserved on upgrade) ---
+  - src: ./packaging/config.yaml
+    dst: /etc/s3-orchestrator/config.yaml
+    type: config|noreplace
+    file_info:
+      mode: 0640
+
+  # --- Data directory ---
+  - dst: /var/lib/s3-orchestrator
+    type: dir
+    file_info:
+      mode: 0750
+
+  # --- Documentation ---
+  - src: ./packaging/copyright
+    dst: /usr/share/doc/s3-orchestrator/copyright
+    file_info:
+      mode: 0644
+
+  - src: ./packaging/changelog.gz
+    dst: /usr/share/doc/s3-orchestrator/changelog.Debian.gz
+    file_info:
+      mode: 0644
+
+  # --- Lintian overrides ---
+  - src: ./packaging/lintian-overrides
+    dst: /usr/share/lintian/overrides/s3-orchestrator
+    file_info:
+      mode: 0644
+
+# -------------------------------------------------------------------------
+# PACKAGE SCRIPTS
+# -------------------------------------------------------------------------
+
+scripts:
+  preinstall: ./packaging/preinstall.sh
+  postinstall: ./packaging/postinstall.sh
+  postremove: ./packaging/postremove.sh
+
+# -------------------------------------------------------------------------
+# DEPENDENCIES
+# -------------------------------------------------------------------------
+
+depends:
+  - systemd

--- a/packaging/changelog
+++ b/packaging/changelog
@@ -1,0 +1,5 @@
+s3-orchestrator (0.6.0-1) stable; urgency=low
+
+  * Initial Debian packaging
+
+ -- Alex Freidah <alex.freidah@gmail.com>  Wed, 25 Feb 2026 00:00:00 +0000

--- a/packaging/copyright
+++ b/packaging/copyright
@@ -1,0 +1,27 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: s3-orchestrator
+Upstream-Contact: Alex Freidah <alex.freidah@gmail.com>
+Source: https://github.com/afreidah/s3-orchestrator
+
+Files: *
+Copyright: 2025-2026 Alex Freidah
+License: MIT
+
+License: MIT
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ .
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.

--- a/packaging/lintian-overrides
+++ b/packaging/lintian-overrides
@@ -1,0 +1,17 @@
+# Go produces statically linked binaries by design
+s3-orchestrator: statically-linked-binary [usr/bin/s3-orchestrator]
+
+# No man page for this service
+s3-orchestrator: no-manual-page [usr/bin/s3-orchestrator]
+
+# Intentional restrictive permissions - config contains database and backend secrets
+s3-orchestrator: non-standard-dir-perm 0750 != 0755 [etc/s3-orchestrator/]
+s3-orchestrator: non-standard-dir-perm 0750 != 0755 [var/lib/s3-orchestrator/]
+s3-orchestrator: non-standard-file-perm 0640 != 0644 [etc/default/s3-orchestrator]
+s3-orchestrator: non-standard-file-perm 0640 != 0644 [etc/s3-orchestrator/config.yaml]
+
+# Private package, not uploaded to Debian archive
+s3-orchestrator: initial-upload-closes-no-bugs [usr/share/doc/s3-orchestrator/changelog.Debian.gz:1]
+
+# Private package uses direct systemctl calls rather than deb-systemd-helper
+s3-orchestrator: maintainer-script-calls-systemctl [postinst:14]

--- a/packaging/postinstall.sh
+++ b/packaging/postinstall.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# -------------------------------------------------------------------------------
+# S3 Orchestrator - Post-Install Script
+#
+# Author: Alex Freidah
+#
+# Reloads systemd unit files and enables the service. Does not start the
+# service automatically to allow the operator to configure it first.
+# -------------------------------------------------------------------------------
+
+set -eu
+
+systemctl daemon-reload
+systemctl enable s3-orchestrator

--- a/packaging/postremove.sh
+++ b/packaging/postremove.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# -------------------------------------------------------------------------------
+# S3 Orchestrator - Post-Remove Script
+#
+# Author: Alex Freidah
+#
+# Cleans up the system user and data directory on package purge. Skips cleanup
+# on plain remove to preserve data for potential reinstall.
+# -------------------------------------------------------------------------------
+
+set -eu
+
+if [ "${1:-}" = "purge" ]; then
+    if getent passwd s3-orchestrator >/dev/null 2>&1; then
+        userdel s3-orchestrator
+    fi
+
+    if getent group s3-orchestrator >/dev/null 2>&1; then
+        groupdel s3-orchestrator
+    fi
+
+    rm -rf /var/lib/s3-orchestrator
+fi

--- a/packaging/preinstall.sh
+++ b/packaging/preinstall.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# -------------------------------------------------------------------------------
+# S3 Orchestrator - Pre-Install Script
+#
+# Author: Alex Freidah
+#
+# Creates the s3-orchestrator system user/group and required directories.
+# Runs before package files are unpacked.
+# -------------------------------------------------------------------------------
+
+set -eu
+
+if ! getent group s3-orchestrator >/dev/null 2>&1; then
+    groupadd --system s3-orchestrator
+fi
+
+if ! getent passwd s3-orchestrator >/dev/null 2>&1; then
+    useradd --system \
+        --gid s3-orchestrator \
+        --home-dir /var/lib/s3-orchestrator \
+        --shell /usr/sbin/nologin \
+        --no-create-home \
+        s3-orchestrator
+fi
+
+install -d -o s3-orchestrator -g s3-orchestrator -m 0750 /var/lib/s3-orchestrator
+install -d -o root -g s3-orchestrator -m 0750 /etc/s3-orchestrator

--- a/packaging/s3-orchestrator.default
+++ b/packaging/s3-orchestrator.default
@@ -1,0 +1,38 @@
+# -------------------------------------------------------------------------------
+# S3 Orchestrator - Default Environment Variables
+#
+# Author: Alex Freidah
+#
+# Environment variables referenced by config.yaml via ${VAR} syntax. Sourced
+# automatically by the systemd service unit. Uncomment and set values as needed.
+# -------------------------------------------------------------------------------
+
+# --- Database credentials ---
+#DB_HOST=localhost
+#DB_PORT=5432
+#DB_NAME=s3_orchestrator
+#DB_USER=s3_orchestrator
+#DB_PASSWORD=changeme
+#DB_SSL_MODE=require
+
+# --- Backend credentials (example for two backends) ---
+#BACKEND1_NAME=primary
+#BACKEND1_ENDPOINT=https://s3.example.com
+#BACKEND1_REGION=us-east-1
+#BACKEND1_BUCKET=my-bucket
+#BACKEND1_ACCESS_KEY=AKIAEXAMPLE
+#BACKEND1_SECRET_KEY=changeme
+
+#BACKEND2_NAME=secondary
+#BACKEND2_ENDPOINT=https://s3.backup.example.com
+#BACKEND2_REGION=us-west-2
+#BACKEND2_BUCKET=my-bucket-backup
+#BACKEND2_ACCESS_KEY=AKIAEXAMPLE2
+#BACKEND2_SECRET_KEY=changeme
+
+# --- Bucket client credentials ---
+#BUCKET_ACCESS_KEY=client-access-key
+#BUCKET_SECRET_KEY=client-secret-key
+
+# --- Telemetry ---
+#TRACING_ENDPOINT=localhost:4317

--- a/packaging/s3-orchestrator.service
+++ b/packaging/s3-orchestrator.service
@@ -1,0 +1,41 @@
+# -------------------------------------------------------------------------------
+# S3 Orchestrator - Systemd Service Unit
+#
+# Author: Alex Freidah
+#
+# Manages the s3-orchestrator process as a systemd service. Runs as a dedicated
+# system user with filesystem and privilege hardening. Supports graceful config
+# reload via SIGHUP and optional environment variable overrides.
+# -------------------------------------------------------------------------------
+
+[Unit]
+Description=S3 Orchestrator - Unified S3 Storage Endpoint
+Documentation=https://github.com/afreidah/s3-orchestrator
+After=network-online.target postgresql.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=s3-orchestrator
+Group=s3-orchestrator
+
+ExecStart=/usr/bin/s3-orchestrator -config /etc/s3-orchestrator/config.yaml
+ExecReload=/bin/kill -HUP $MAINPID
+
+Restart=on-failure
+RestartSec=5s
+
+# --- Optional environment overrides for ${VAR} expansion in config.yaml ---
+EnvironmentFile=-/etc/default/s3-orchestrator
+
+# --- Resource limits ---
+LimitNOFILE=65536
+
+# --- Security hardening ---
+ProtectSystem=strict
+ProtectHome=yes
+NoNewPrivileges=yes
+ReadWritePaths=/var/lib/s3-orchestrator
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
  Support bare-metal/VM deployments by packaging s3-orchestrator as a .deb
  with a hardened systemd unit, sample config, environment file, and
  maintainer scripts for user/directory lifecycle. Uses nfpm for package
  generation with multi-arch (amd64/arm64) support and lintian validation.

  Adds deb, deb-lint, deb-all, and tools targets to the Makefile, and a
  package job to the CI pipeline that builds both architectures and runs
  lintian on every push and PR.