### PR TITLE
feat: add S3 DeleteObjects batch API

### DIFF
--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -542,8 +542,8 @@ Key audit events:
 
 | Event | Source | Description |
 |-------|--------|-------------|
-| `s3.PutObject`, `s3.GetObject`, etc. | HTTP layer | S3 API request with method, path, bucket, status, duration |
-| `storage.PutObject`, `storage.GetObject`, etc. | Storage layer | Backend operation with key, backend name, size |
+| `s3.PutObject`, `s3.GetObject`, `s3.DeleteObjects`, etc. | HTTP layer | S3 API request with method, path, bucket, status, duration |
+| `storage.PutObject`, `storage.GetObject`, `storage.DeleteObjects`, etc. | Storage layer | Backend operation with key, backend name, size |
 | `rebalance.start`, `rebalance.move`, `rebalance.complete` | Rebalancer | Object redistribution runs |
 | `replication.start`, `replication.copy`, `replication.complete` | Replicator | Replica creation runs |
 | `storage.MultipartCleanup` | Multipart cleanup | Stale upload cleanup |
@@ -643,7 +643,7 @@ To perform a zero-downtime credential rotation, temporarily add both old and new
 make build
 
 # Multi-arch build and push to registry with version tag
-make push VERSION=v0.6.1
+make push VERSION=v0.6.2
 ```
 
 The `VERSION` is baked into the binary via `-ldflags` and displayed in the web UI and `/health` endpoint. Use versioned tags (not `latest`) to avoid Docker layer caching issues on orchestration platforms.
@@ -671,19 +671,19 @@ Build a `.deb` package for bare-metal or VM deployments:
 
 ```bash
 # Build for host architecture
-make deb VERSION=0.6.1
+make deb VERSION=0.6.2
 
 # Build for both amd64 and arm64
-make deb-all VERSION=0.6.1
+make deb-all VERSION=0.6.2
 
 # Build and validate with lintian
-make deb-lint VERSION=0.6.1
+make deb-lint VERSION=0.6.2
 ```
 
 Install and configure:
 
 ```bash
-sudo dpkg -i s3-orchestrator_0.6.1_amd64.deb
+sudo dpkg -i s3-orchestrator_0.6.2_amd64.deb
 
 # Edit the config — set database, backends, buckets
 sudo vim /etc/s3-orchestrator/config.yaml

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -66,6 +66,9 @@ s3o s3api list-objects-v2 --bucket app1-files --prefix "photos/"
 
 ```bash
 s3o s3 rm s3://app1-files/path/to/myfile.txt
+
+# Delete all files under a prefix (uses batch DeleteObjects internally)
+s3o s3 rm s3://app1-files/old-backups/ --recursive
 ```
 
 ### Copy within the bucket

--- a/internal/storage/mock_store_test.go
+++ b/internal/storage/mock_store_test.go
@@ -23,6 +23,7 @@ type mockStore struct {
 
 	deleteObjectResp []DeletedCopy
 	deleteObjectErr  error
+	deleteObjectFunc func(key string) ([]DeletedCopy, error)
 
 	listObjectsResp  *ListObjectsResult
 	listObjectsPages []ListObjectsResult // for paginated tests
@@ -144,6 +145,9 @@ func (m *mockStore) DeleteObject(_ context.Context, key string) ([]DeletedCopy, 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.deleteObjectCalls = append(m.deleteObjectCalls, key)
+	if m.deleteObjectFunc != nil {
+		return m.deleteObjectFunc(key)
+	}
 	if m.deleteObjectErr != nil {
 		return nil, m.deleteObjectErr
 	}

--- a/internal/testutil/mock_store.go
+++ b/internal/testutil/mock_store.go
@@ -26,6 +26,7 @@ type MockStore struct {
 
 	DeleteObjectResp []storage.DeletedCopy
 	DeleteObjectErr  error
+	DeleteObjectFunc func(key string) ([]storage.DeletedCopy, error)
 
 	ListObjectsResp  *storage.ListObjectsResult
 	ListObjectsPages []storage.ListObjectsResult // for paginated tests
@@ -126,6 +127,9 @@ func (m *MockStore) DeleteObject(_ context.Context, key string) ([]storage.Delet
 	m.Mu.Lock()
 	defer m.Mu.Unlock()
 	m.DeleteObjectCalls = append(m.DeleteObjectCalls, key)
+	if m.DeleteObjectFunc != nil {
+		return m.DeleteObjectFunc(key)
+	}
 	if m.DeleteObjectErr != nil {
 		return nil, m.DeleteObjectErr
 	}

--- a/packaging/changelog
+++ b/packaging/changelog
@@ -1,10 +1,19 @@
+s3-orchestrator (0.6.2-1) stable; urgency=low
+
+  * Add S3 DeleteObjects batch API (up to 1000 keys)
+  * Concurrent backend deletes with bounded parallelism
+  * Quiet mode suppresses success elements in response
+  * Failed backend deletes enqueue to cleanup queue
+
+ -- Alex Freidah <alex.freidah@gmail.com>  Wed, 25 Feb 2026 12:00:00 +0000
+
 s3-orchestrator (0.6.1-1) stable; urgency=low
 
   * Add cleanup retry queue for failed backend deletions
-  * Background worker retries orphaned object cleanups with exponential backoff
-  * New Prometheus metrics: cleanup_queue_enqueued_total, cleanup_queue_processed_total, cleanup_queue_depth
+  * Background worker retries orphaned object cleanups
+  * New metrics: cleanup_queue_enqueued, processed, depth
 
- -- Alex Freidah <alex.freidah@gmail.com>  Tue, 25 Feb 2026 00:00:00 +0000
+ -- Alex Freidah <alex.freidah@gmail.com>  Wed, 25 Feb 2026 00:00:00 +0000
 
 s3-orchestrator (0.6.0-1) stable; urgency=low
 


### PR DESCRIPTION
  Support batch deletion of up to 1000 keys per request via POST
  /{bucket}?delete. Metadata removal runs sequentially per key (reusing
  existing store.DeleteObject transactions), while backend S3 deletes run
  concurrently with a 10-goroutine semaphore to avoid overwhelming
  backends. Failed backend deletes enqueue to the cleanup queue for
  automatic retry.

  Supports quiet mode (suppress Deleted elements in response XML) and
  always returns HTTP 200 per S3 spec, with per-key errors in the body.