### PR TITLE
feat: parallel rebalance move execution

### DIFF
--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -263,10 +263,13 @@ rebalance:
   interval: "6h"                 # default: 6h
   batch_size: 100                # objects per run (default: 100)
   threshold: 0.1                 # min utilization spread to trigger (default: 0.1)
+  concurrency: 5                 # parallel moves per run (default: 5)
 ```
 
 - **pack** — fills backends in config order, consolidating free space onto the last backend. Good for maximizing free-tier allocations.
 - **spread** — equalizes utilization ratios across all backends. Good for distributing load.
+
+Object moves run concurrently within each batch, bounded by `concurrency`. Increase for faster rebalancing; decrease to reduce backend load.
 
 ### replication
 
@@ -643,7 +646,7 @@ To perform a zero-downtime credential rotation, temporarily add both old and new
 make build
 
 # Multi-arch build and push to registry with version tag
-make push VERSION=v0.6.2
+make push VERSION=v0.6.3
 ```
 
 The `VERSION` is baked into the binary via `-ldflags` and displayed in the web UI and `/health` endpoint. Use versioned tags (not `latest`) to avoid Docker layer caching issues on orchestration platforms.
@@ -671,19 +674,19 @@ Build a `.deb` package for bare-metal or VM deployments:
 
 ```bash
 # Build for host architecture
-make deb VERSION=0.6.2
+make deb VERSION=0.6.3
 
 # Build for both amd64 and arm64
-make deb-all VERSION=0.6.2
+make deb-all VERSION=0.6.3
 
 # Build and validate with lintian
-make deb-lint VERSION=0.6.2
+make deb-lint VERSION=0.6.3
 ```
 
 Install and configure:
 
 ```bash
-sudo dpkg -i s3-orchestrator_0.6.2_amd64.deb
+sudo dpkg -i s3-orchestrator_0.6.3_amd64.deb
 
 # Edit the config — set database, backends, buckets
 sudo vim /etc/s3-orchestrator/config.yaml

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -125,11 +125,12 @@ type TracingConfig struct {
 // RebalanceConfig holds settings for the periodic backend rebalancer.
 // Disabled by default to avoid unexpected API calls and egress charges.
 type RebalanceConfig struct {
-	Enabled   bool          `yaml:"enabled"`
-	Strategy  string        `yaml:"strategy"`   // "pack" or "spread"
-	Interval  time.Duration `yaml:"interval"`
-	BatchSize int           `yaml:"batch_size"`
-	Threshold float64       `yaml:"threshold"`  // min utilization spread to trigger
+	Enabled     bool          `yaml:"enabled"`
+	Strategy    string        `yaml:"strategy"`    // "pack" or "spread"
+	Interval    time.Duration `yaml:"interval"`
+	BatchSize   int           `yaml:"batch_size"`
+	Threshold   float64       `yaml:"threshold"`   // min utilization spread to trigger
+	Concurrency int           `yaml:"concurrency"` // parallel moves (default: 5)
 }
 
 // ReplicationConfig holds settings for the background replication worker.
@@ -399,6 +400,9 @@ func (c *Config) SetDefaultsAndValidate() error {
 		if c.Rebalance.Threshold == 0 {
 			c.Rebalance.Threshold = 0.1
 		}
+		if c.Rebalance.Concurrency == 0 {
+			c.Rebalance.Concurrency = 5
+		}
 
 		// --- Rebalance validation ---
 		if c.Rebalance.Strategy != "pack" && c.Rebalance.Strategy != "spread" {
@@ -412,6 +416,9 @@ func (c *Config) SetDefaultsAndValidate() error {
 		}
 		if c.Rebalance.Threshold < 0 || c.Rebalance.Threshold > 1 {
 			errors = append(errors, "rebalance.threshold must be between 0 and 1")
+		}
+		if c.Rebalance.Concurrency <= 0 {
+			errors = append(errors, "rebalance.concurrency must be positive")
 		}
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -159,6 +159,9 @@ func TestRebalanceConfig_Defaults(t *testing.T) {
 	if cfg.Rebalance.Threshold != 0.1 {
 		t.Errorf("threshold default = %f, want 0.1", cfg.Rebalance.Threshold)
 	}
+	if cfg.Rebalance.Concurrency != 5 {
+		t.Errorf("concurrency default = %d, want 5", cfg.Rebalance.Concurrency)
+	}
 }
 
 func TestRebalanceConfig_InvalidStrategy(t *testing.T) {

--- a/internal/storage/rebalancer_test.go
+++ b/internal/storage/rebalancer_test.go
@@ -1,0 +1,240 @@
+// -------------------------------------------------------------------------------
+// Rebalancer Tests - Move Execution Concurrency
+//
+// Author: Alex Freidah
+//
+// Unit tests for the parallel move execution in the rebalancer. Verifies that
+// concurrent moves complete correctly, partial failures are handled, and
+// sequential fallback (concurrency=1) works identically to the old behavior.
+// -------------------------------------------------------------------------------
+
+package storage
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"sync"
+	"testing"
+	"time"
+)
+
+// -------------------------------------------------------------------------
+// HELPERS
+// -------------------------------------------------------------------------
+
+// delayedGetBackend wraps mockBackend and adds a delay to GetObject
+// to simulate real backend latency for concurrency testing.
+type delayedGetBackend struct {
+	mu      sync.Mutex
+	objects map[string]mockObject
+	putErr  error
+	getErr  error
+	headErr error
+	delErr  error
+	delay   time.Duration
+}
+
+func newDelayedGetBackend(delay time.Duration) *delayedGetBackend {
+	return &delayedGetBackend{
+		objects: make(map[string]mockObject),
+		delay:   delay,
+	}
+}
+
+var _ ObjectBackend = (*delayedGetBackend)(nil)
+
+func (m *delayedGetBackend) PutObject(_ context.Context, key string, body io.Reader, _ int64, contentType string) (string, error) {
+	m.mu.Lock()
+	err := m.putErr
+	m.mu.Unlock()
+	if err != nil {
+		return "", err
+	}
+	data, err := io.ReadAll(body)
+	if err != nil {
+		return "", err
+	}
+	etag := fmt.Sprintf(`"%x"`, len(data))
+	m.mu.Lock()
+	m.objects[key] = mockObject{data: data, contentType: contentType, etag: etag}
+	m.mu.Unlock()
+	return etag, nil
+}
+
+func (m *delayedGetBackend) GetObject(_ context.Context, key string, _ string) (*GetObjectResult, error) {
+	time.Sleep(m.delay)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+	obj, ok := m.objects[key]
+	if !ok {
+		return nil, fmt.Errorf("object %q not found", key)
+	}
+	cp := make([]byte, len(obj.data))
+	copy(cp, obj.data)
+	return &GetObjectResult{
+		Body:        io.NopCloser(bytes.NewReader(cp)),
+		Size:        int64(len(cp)),
+		ContentType: obj.contentType,
+		ETag:        obj.etag,
+	}, nil
+}
+
+func (m *delayedGetBackend) HeadObject(_ context.Context, key string) (int64, string, string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.headErr != nil {
+		return 0, "", "", m.headErr
+	}
+	obj, ok := m.objects[key]
+	if !ok {
+		return 0, "", "", fmt.Errorf("object %q not found", key)
+	}
+	return int64(len(obj.data)), obj.contentType, obj.etag, nil
+}
+
+func (m *delayedGetBackend) DeleteObject(_ context.Context, key string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.delErr != nil {
+		return m.delErr
+	}
+	delete(m.objects, key)
+	return nil
+}
+
+func (m *delayedGetBackend) seedObject(key string, data []byte) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.objects[key] = mockObject{data: data, contentType: "application/octet-stream"}
+}
+
+func (m *delayedGetBackend) hasObject(key string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	_, ok := m.objects[key]
+	return ok
+}
+
+// -------------------------------------------------------------------------
+// TESTS
+// -------------------------------------------------------------------------
+
+func TestExecuteMoves_Concurrent(t *testing.T) {
+	src := newDelayedGetBackend(50 * time.Millisecond)
+	dest := newDelayedGetBackend(0)
+
+	for i := range 5 {
+		src.seedObject(fmt.Sprintf("key%d", i), []byte("data"))
+	}
+
+	store := &mockStore{moveObjectLocationSize: 4}
+	obs := map[string]ObjectBackend{"src": src, "dest": dest}
+	mgr := NewBackendManager(&BackendManagerConfig{
+		Backends:        obs,
+		Store:           store,
+		Order:           []string{"src", "dest"},
+		CacheTTL:        5 * time.Second,
+		BackendTimeout:  30 * time.Second,
+		RoutingStrategy: "pack",
+	})
+
+	var plan []rebalanceMove
+	for i := range 5 {
+		plan = append(plan, rebalanceMove{
+			ObjectKey:   fmt.Sprintf("key%d", i),
+			FromBackend: "src",
+			ToBackend:   "dest",
+			SizeBytes:   4,
+		})
+	}
+
+	start := time.Now()
+	moved := mgr.executeMoves(context.Background(), plan, "spread", 3)
+	elapsed := time.Since(start)
+
+	if moved != 5 {
+		t.Errorf("moved = %d, want 5", moved)
+	}
+
+	// 5 moves at 50ms each with concurrency 3 should take ~100ms (2 batches),
+	// not 250ms (sequential). Allow generous margin for CI.
+	if elapsed > 200*time.Millisecond {
+		t.Errorf("elapsed = %v, expected < 200ms with concurrency 3", elapsed)
+	}
+
+	// Verify objects landed on dest
+	for i := range 5 {
+		if !dest.hasObject(fmt.Sprintf("key%d", i)) {
+			t.Errorf("key%d not found on destination", i)
+		}
+	}
+}
+
+func TestExecuteMoves_PartialFailure(t *testing.T) {
+	src := newDelayedGetBackend(0)
+	dest := newDelayedGetBackend(0)
+
+	src.seedObject("ok1", []byte("data"))
+	src.seedObject("ok2", []byte("data"))
+
+	store := &mockStore{moveObjectLocationSize: 4}
+	obs := map[string]ObjectBackend{"src": src, "dest": dest}
+	mgr := NewBackendManager(&BackendManagerConfig{
+		Backends:        obs,
+		Store:           store,
+		Order:           []string{"src", "dest"},
+		CacheTTL:        5 * time.Second,
+		BackendTimeout:  30 * time.Second,
+		RoutingStrategy: "pack",
+	})
+
+	// "fail" key does not exist on source, so GetObject returns not-found
+	plan := []rebalanceMove{
+		{ObjectKey: "ok1", FromBackend: "src", ToBackend: "dest", SizeBytes: 4},
+		{ObjectKey: "fail", FromBackend: "src", ToBackend: "dest", SizeBytes: 4},
+		{ObjectKey: "ok2", FromBackend: "src", ToBackend: "dest", SizeBytes: 4},
+	}
+
+	moved := mgr.executeMoves(context.Background(), plan, "spread", 3)
+	if moved != 2 {
+		t.Errorf("moved = %d, want 2 (one should fail)", moved)
+	}
+}
+
+func TestExecuteMoves_SequentialFallback(t *testing.T) {
+	src := newDelayedGetBackend(0)
+	dest := newDelayedGetBackend(0)
+
+	src.seedObject("a", []byte("hello"))
+	src.seedObject("b", []byte("world"))
+
+	store := &mockStore{moveObjectLocationSize: 5}
+	obs := map[string]ObjectBackend{"src": src, "dest": dest}
+	mgr := NewBackendManager(&BackendManagerConfig{
+		Backends:        obs,
+		Store:           store,
+		Order:           []string{"src", "dest"},
+		CacheTTL:        5 * time.Second,
+		BackendTimeout:  30 * time.Second,
+		RoutingStrategy: "pack",
+	})
+
+	plan := []rebalanceMove{
+		{ObjectKey: "a", FromBackend: "src", ToBackend: "dest", SizeBytes: 5},
+		{ObjectKey: "b", FromBackend: "src", ToBackend: "dest", SizeBytes: 5},
+	}
+
+	moved := mgr.executeMoves(context.Background(), plan, "pack", 1)
+	if moved != 2 {
+		t.Errorf("moved = %d, want 2", moved)
+	}
+
+	if !dest.hasObject("a") || !dest.hasObject("b") {
+		t.Error("expected both objects on destination")
+	}
+}

--- a/packaging/changelog
+++ b/packaging/changelog
@@ -1,3 +1,10 @@
+s3-orchestrator (0.6.3-1) stable; urgency=low
+
+  * Parallel rebalance move execution with bounded concurrency
+  * New config: rebalance.concurrency (default: 5)
+
+ -- Alex Freidah <alex.freidah@gmail.com>  Wed, 25 Feb 2026 18:00:00 +0000
+
 s3-orchestrator (0.6.2-1) stable; urgency=low
 
   * Add S3 DeleteObjects batch API (up to 1000 keys)


### PR DESCRIPTION
  Rebalancer moves now run concurrently with bounded parallelism instead
  of sequentially. New rebalance.concurrency config (default: 5) controls
  the number of parallel moves per batch. Falls back to sequential when
  set to 1 or omitted.