### PR TITLE
feat: optional parallel broadcast reads in degraded mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ closed (healthy) → open (DB down) → half-open (probing) → closed
 
 When the database becomes unreachable (consecutive failures exceed `failure_threshold`), the orchestrator enters **degraded mode**:
 
-- **Reads** broadcast to all backends in order. A location cache (TTL configurable via `cache_ttl`) stores successful lookups to avoid repeated broadcasts for the same key.
+- **Reads** broadcast to all backends in order (or in parallel if `parallel_broadcast` is enabled). A location cache (TTL configurable via `cache_ttl`) stores successful lookups to avoid repeated broadcasts for the same key.
 - **Writes** (PUT, DELETE, COPY, multipart) return `503 ServiceUnavailable`.
 - **Health endpoint** returns `degraded` instead of `ok`.
 
@@ -228,6 +228,7 @@ circuit_breaker:
   failure_threshold: 3     # consecutive DB failures before opening (default: 3)
   open_timeout: "15s"      # delay before probing recovery (default: 15s)
   cache_ttl: "60s"         # key→backend cache TTL during degraded reads (default: 60s)
+  parallel_broadcast: false # fan-out reads to all backends in parallel during degraded mode (default: false)
 
 rebalance:
   enabled: false
@@ -285,6 +286,7 @@ kill -HUP $(pidof s3-orchestrator)
 | `server.listen_addr` | No | Requires restart |
 | `database` | No | Requires restart |
 | `telemetry` | No | Requires restart |
+| `circuit_breaker` | No | Requires restart |
 | `ui` | No | Requires restart |
 | `routing_strategy` | No | Requires restart |
 | `backends` (structural: endpoint, credentials, count) | No | Requires restart |

--- a/cmd/s3-orchestrator/main.go
+++ b/cmd/s3-orchestrator/main.go
@@ -129,13 +129,14 @@ func runServe() {
 
 	// --- Create backend manager ---
 	manager := storage.NewBackendManager(&storage.BackendManagerConfig{
-		Backends:        backends,
-		Store:           cbStore,
-		Order:           backendOrder,
-		CacheTTL:        cfg.CircuitBreaker.CacheTTL,
-		BackendTimeout:  cfg.Server.BackendTimeout,
-		UsageLimits:     usageLimits,
-		RoutingStrategy: cfg.RoutingStrategy,
+		Backends:          backends,
+		Store:             cbStore,
+		Order:             backendOrder,
+		CacheTTL:          cfg.CircuitBreaker.CacheTTL,
+		BackendTimeout:    cfg.Server.BackendTimeout,
+		UsageLimits:       usageLimits,
+		RoutingStrategy:   cfg.RoutingStrategy,
+		ParallelBroadcast: cfg.CircuitBreaker.ParallelBroadcast,
 	})
 
 	// --- Store initial reloadable configs ---
@@ -429,6 +430,10 @@ func runServe() {
 			"min_version", cfg.Server.TLS.MinVersion,
 			"mtls", cfg.Server.TLS.ClientCAFile != "",
 		)
+	}
+
+	if cfg.CircuitBreaker.ParallelBroadcast {
+		slog.Info("Parallel broadcast reads enabled for degraded mode")
 	}
 
 	// --- Start server ---

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -155,9 +155,10 @@ type RateLimitConfig struct {
 // the database becomes unreachable, the proxy enters degraded mode: reads
 // broadcast to all backends, writes return 503.
 type CircuitBreakerConfig struct {
-	FailureThreshold int           `yaml:"failure_threshold"` // Consecutive failures before opening (default: 3)
-	OpenTimeout      time.Duration `yaml:"open_timeout"`      // Delay before probing recovery (default: 15s)
-	CacheTTL         time.Duration `yaml:"cache_ttl"`         // TTL for key→backend cache during degraded reads (default: 60s)
+	FailureThreshold  int           `yaml:"failure_threshold"`  // Consecutive failures before opening (default: 3)
+	OpenTimeout       time.Duration `yaml:"open_timeout"`       // Delay before probing recovery (default: 15s)
+	CacheTTL          time.Duration `yaml:"cache_ttl"`          // TTL for key→backend cache during degraded reads (default: 60s)
+	ParallelBroadcast bool          `yaml:"parallel_broadcast"` // Fan-out reads to all backends in parallel during degraded mode (default: false)
 }
 
 // UIConfig holds settings for the built-in web dashboard. Disabled by default.
@@ -545,6 +546,9 @@ func NonReloadableFieldsChanged(old, new *Config) []string {
 	}
 	if old.UI != new.UI {
 		changed = append(changed, "ui")
+	}
+	if old.CircuitBreaker != new.CircuitBreaker {
+		changed = append(changed, "circuit_breaker")
 	}
 	if old.RoutingStrategy != new.RoutingStrategy {
 		changed = append(changed, "routing_strategy")

--- a/packaging/changelog
+++ b/packaging/changelog
@@ -1,3 +1,11 @@
+s3-orchestrator (0.6.5-1) stable; urgency=low
+
+  * Optional parallel broadcast reads in degraded mode (circuit_breaker.parallel_broadcast)
+  * Reduces worst-case degraded read latency from N*timeout to single backend response time
+  * circuit_breaker section added to non-reloadable fields check
+
+ -- Alex Freidah <alex.freidah@gmail.com>  Tue, 25 Feb 2026 22:00:00 +0000
+
 s3-orchestrator (0.6.4-1) stable; urgency=low
 
   * PostgreSQL advisory locks for multi-instance background task coordination


### PR DESCRIPTION
  When the circuit breaker is open, degraded reads now support parallel
  fan-out to all backends instead of sequential iteration. First success
  wins and remaining goroutines are cancelled via context. Opt-in via
  circuit_breaker.parallel_broadcast (default: false) since parallel
  broadcasts multiply API calls against backends.

  Adds sync.Once guard to GetObject callback to prevent closure races
  when multiple backends succeed simultaneously.