### PR TITLE
feat: add lifecycle rules for automatic object expiration

### DIFF
--- a/internal/storage/circuitbreaker.go
+++ b/internal/storage/circuitbreaker.go
@@ -279,6 +279,10 @@ func (cb *CircuitBreakerStore) DeleteMultipartUpload(ctx context.Context, upload
 	return cbCallNoResult(cb, func() error { return cb.real.DeleteMultipartUpload(ctx, uploadID) })
 }
 
+func (cb *CircuitBreakerStore) ListExpiredObjects(ctx context.Context, prefix string, cutoff time.Time, limit int) ([]ObjectLocation, error) {
+	return cbCall(cb, func() ([]ObjectLocation, error) { return cb.real.ListExpiredObjects(ctx, prefix, cutoff, limit) })
+}
+
 func (cb *CircuitBreakerStore) GetQuotaStats(ctx context.Context) (map[string]QuotaStat, error) {
 	return cbCall(cb, func() (map[string]QuotaStat, error) { return cb.real.GetQuotaStats(ctx) })
 }

--- a/internal/storage/manager.go
+++ b/internal/storage/manager.go
@@ -79,6 +79,7 @@ type BackendManager struct {
 	rebalanceCfg      atomic.Pointer[config.RebalanceConfig]
 	replicationCfg  atomic.Pointer[config.ReplicationConfig]
 	usageFlushCfg   atomic.Pointer[config.UsageFlushConfig]
+	lifecycleCfg    atomic.Pointer[config.LifecycleConfig]
 }
 
 // NewBackendManager creates a new backend manager with the given configuration.
@@ -159,6 +160,16 @@ func (m *BackendManager) SetUsageFlushConfig(cfg *config.UsageFlushConfig) {
 // UsageFlushConfig returns the current usage flush configuration.
 func (m *BackendManager) UsageFlushConfig() *config.UsageFlushConfig {
 	return m.usageFlushCfg.Load()
+}
+
+// SetLifecycleConfig atomically stores the lifecycle configuration.
+func (m *BackendManager) SetLifecycleConfig(cfg *config.LifecycleConfig) {
+	m.lifecycleCfg.Store(cfg)
+}
+
+// LifecycleConfig returns the current lifecycle configuration.
+func (m *BackendManager) LifecycleConfig() *config.LifecycleConfig {
+	return m.lifecycleCfg.Load()
 }
 
 // NearUsageLimit returns true if any backend is approaching its usage limits.

--- a/internal/storage/manager_lifecycle.go
+++ b/internal/storage/manager_lifecycle.go
@@ -1,0 +1,65 @@
+// -------------------------------------------------------------------------------
+// Lifecycle - Automatic Object Expiration
+//
+// Author: Alex Freidah
+//
+// Evaluates lifecycle rules and deletes objects whose created_at timestamp is
+// older than the configured expiration period. Reuses the existing DeleteObject
+// path for quota decrement, cache invalidation, and cleanup queue.
+// -------------------------------------------------------------------------------
+
+package storage
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/afreidah/s3-orchestrator/internal/config"
+	"github.com/afreidah/s3-orchestrator/internal/telemetry"
+)
+
+const lifecycleBatchSize = 100
+
+// ProcessLifecycleRules evaluates all lifecycle rules and deletes expired
+// objects. Returns total deleted and failed counts.
+func (m *BackendManager) ProcessLifecycleRules(ctx context.Context, rules []config.LifecycleRule) (deleted, failed int) {
+	for _, rule := range rules {
+		cutoff := time.Now().Add(-time.Duration(rule.ExpirationDays) * 24 * time.Hour)
+
+		for {
+			objects, err := m.store.ListExpiredObjects(ctx, rule.Prefix, cutoff, lifecycleBatchSize)
+			if err != nil {
+				slog.Error("Lifecycle: failed to list expired objects",
+					"prefix", rule.Prefix, "error", err)
+				failed++
+				break
+			}
+
+			if len(objects) == 0 {
+				break
+			}
+
+			for _, obj := range objects {
+				if err := m.DeleteObject(ctx, obj.ObjectKey); err != nil {
+					slog.Warn("Lifecycle: failed to delete expired object",
+						"key", obj.ObjectKey, "error", err)
+					telemetry.LifecycleFailedTotal.Inc()
+					failed++
+				} else {
+					slog.Debug("Lifecycle: deleted expired object",
+						"key", obj.ObjectKey, "prefix", rule.Prefix,
+						"age_days", rule.ExpirationDays)
+					telemetry.LifecycleDeletedTotal.Inc()
+					deleted++
+				}
+			}
+
+			// If we got fewer than batchSize, we've exhausted this rule.
+			if len(objects) < lifecycleBatchSize {
+				break
+			}
+		}
+	}
+	return deleted, failed
+}

--- a/internal/storage/manager_lifecycle_test.go
+++ b/internal/storage/manager_lifecycle_test.go
@@ -1,0 +1,164 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/afreidah/s3-orchestrator/internal/config"
+)
+
+func TestProcessLifecycleRules_DeletesExpiredObjects(t *testing.T) {
+	backend := newMockBackend()
+	backend.objects["tmp/old-file"] = mockObject{data: []byte("data")}
+	store := &mockStore{
+		listExpiredObjectsResp: []ObjectLocation{
+			{ObjectKey: "tmp/old-file", BackendName: "b1", SizeBytes: 4, CreatedAt: time.Now().Add(-48 * time.Hour)},
+		},
+		deleteObjectResp: []DeletedCopy{{BackendName: "b1", SizeBytes: 4}},
+	}
+	mgr := newTestManager(store, map[string]*mockBackend{"b1": backend})
+
+	rules := []config.LifecycleRule{
+		{Prefix: "tmp/", ExpirationDays: 1},
+	}
+
+	deleted, failed := mgr.ProcessLifecycleRules(context.Background(), rules)
+	if deleted != 1 {
+		t.Errorf("expected 1 deleted, got %d", deleted)
+	}
+	if failed != 0 {
+		t.Errorf("expected 0 failed, got %d", failed)
+	}
+	if len(store.deleteObjectCalls) != 1 {
+		t.Fatalf("expected 1 DeleteObject call, got %d", len(store.deleteObjectCalls))
+	}
+	if store.deleteObjectCalls[0] != "tmp/old-file" {
+		t.Errorf("expected delete of 'tmp/old-file', got %q", store.deleteObjectCalls[0])
+	}
+}
+
+func TestProcessLifecycleRules_NoExpiredObjects(t *testing.T) {
+	store := &mockStore{
+		listExpiredObjectsResp: nil, // no expired objects
+	}
+	mgr := newTestManager(store, map[string]*mockBackend{"b1": newMockBackend()})
+
+	rules := []config.LifecycleRule{
+		{Prefix: "tmp/", ExpirationDays: 7},
+	}
+
+	deleted, failed := mgr.ProcessLifecycleRules(context.Background(), rules)
+	if deleted != 0 {
+		t.Errorf("expected 0 deleted, got %d", deleted)
+	}
+	if failed != 0 {
+		t.Errorf("expected 0 failed, got %d", failed)
+	}
+	if len(store.deleteObjectCalls) != 0 {
+		t.Errorf("expected 0 DeleteObject calls, got %d", len(store.deleteObjectCalls))
+	}
+}
+
+func TestProcessLifecycleRules_MultipleRules(t *testing.T) {
+	backend := newMockBackend()
+	backend.objects["tmp/a"] = mockObject{data: []byte("x")}
+	backend.objects["uploads/staging/b"] = mockObject{data: []byte("y")}
+
+	store := &mockStore{
+		deleteObjectResp: []DeletedCopy{{BackendName: "b1", SizeBytes: 1}},
+	}
+	// Each rule's batch is under lifecycleBatchSize, so the loop breaks without
+	// a second call per rule — no nil terminators needed.
+	store.listExpiredObjectsPages = [][]ObjectLocation{
+		{{ObjectKey: "tmp/a", BackendName: "b1", SizeBytes: 1, CreatedAt: time.Now().Add(-48 * time.Hour)}},
+		{{ObjectKey: "uploads/staging/b", BackendName: "b1", SizeBytes: 1, CreatedAt: time.Now().Add(-3 * time.Hour)}},
+	}
+	mgr := newTestManager(store, map[string]*mockBackend{"b1": backend})
+
+	rules := []config.LifecycleRule{
+		{Prefix: "tmp/", ExpirationDays: 1},
+		{Prefix: "uploads/staging/", ExpirationDays: 1},
+	}
+
+	deleted, failed := mgr.ProcessLifecycleRules(context.Background(), rules)
+	if deleted != 2 {
+		t.Errorf("expected 2 deleted, got %d", deleted)
+	}
+	if failed != 0 {
+		t.Errorf("expected 0 failed, got %d", failed)
+	}
+}
+
+func TestProcessLifecycleRules_BatchPagination(t *testing.T) {
+	backend := newMockBackend()
+	store := &mockStore{
+		deleteObjectResp: []DeletedCopy{{BackendName: "b1", SizeBytes: 1}},
+	}
+
+	// Build a batch of exactly lifecycleBatchSize objects, then an empty page
+	batch := make([]ObjectLocation, lifecycleBatchSize)
+	for i := range batch {
+		key := "tmp/" + string(rune('a'+i%26)) + string(rune('0'+i/26))
+		batch[i] = ObjectLocation{ObjectKey: key, BackendName: "b1", SizeBytes: 1, CreatedAt: time.Now().Add(-48 * time.Hour)}
+		backend.objects[key] = mockObject{data: []byte("x")}
+	}
+	store.listExpiredObjectsPages = [][]ObjectLocation{
+		batch,
+		nil, // second page empty = done
+	}
+
+	mgr := newTestManager(store, map[string]*mockBackend{"b1": backend})
+
+	rules := []config.LifecycleRule{
+		{Prefix: "tmp/", ExpirationDays: 1},
+	}
+
+	deleted, failed := mgr.ProcessLifecycleRules(context.Background(), rules)
+	if deleted != lifecycleBatchSize {
+		t.Errorf("expected %d deleted, got %d", lifecycleBatchSize, deleted)
+	}
+	if failed != 0 {
+		t.Errorf("expected 0 failed, got %d", failed)
+	}
+}
+
+func TestProcessLifecycleRules_DeleteFailureContinues(t *testing.T) {
+	backend := newMockBackend()
+	store := &mockStore{
+		listExpiredObjectsResp: []ObjectLocation{
+			{ObjectKey: "tmp/a", BackendName: "b1", SizeBytes: 1},
+			{ObjectKey: "tmp/b", BackendName: "b1", SizeBytes: 1},
+		},
+		// DeleteObject will fail for all keys
+		deleteObjectErr: errors.New("backend unreachable"),
+	}
+	mgr := newTestManager(store, map[string]*mockBackend{"b1": backend})
+
+	rules := []config.LifecycleRule{
+		{Prefix: "tmp/", ExpirationDays: 1},
+	}
+
+	deleted, failed := mgr.ProcessLifecycleRules(context.Background(), rules)
+	if deleted != 0 {
+		t.Errorf("expected 0 deleted, got %d", deleted)
+	}
+	if failed != 2 {
+		t.Errorf("expected 2 failed, got %d", failed)
+	}
+	// Both objects should have been attempted
+	if len(store.deleteObjectCalls) != 2 {
+		t.Errorf("expected 2 DeleteObject calls, got %d", len(store.deleteObjectCalls))
+	}
+}
+
+func TestProcessLifecycleRules_EmptyRulesNoOp(t *testing.T) {
+	store := &mockStore{}
+	mgr := newTestManager(store, map[string]*mockBackend{"b1": newMockBackend()})
+
+	deleted, failed := mgr.ProcessLifecycleRules(context.Background(), nil)
+	if deleted != 0 || failed != 0 {
+		t.Errorf("expected no-op, got deleted=%d failed=%d", deleted, failed)
+	}
+}

--- a/internal/storage/metadata.go
+++ b/internal/storage/metadata.go
@@ -65,6 +65,9 @@ type MetadataStore interface {
 	// --- Directory listing (dashboard) ---
 	ListDirectoryChildren(ctx context.Context, prefix, startAfter string, maxKeys int) (*DirectoryListResult, error)
 
+	// --- Lifecycle operations ---
+	ListExpiredObjects(ctx context.Context, prefix string, cutoff time.Time, limit int) ([]ObjectLocation, error)
+
 	// --- Background operations (metrics, cleanup, rebalance, replication) ---
 	GetQuotaStats(ctx context.Context) (map[string]QuotaStat, error)
 	GetObjectCounts(ctx context.Context) (map[string]int64, error)

--- a/internal/storage/sqlc/queries/objects.sql
+++ b/internal/storage/sqlc/queries/objects.sql
@@ -75,6 +75,14 @@ WHERE object_key LIKE @prefix::text || '%' ESCAPE '\'
 GROUP BY name, is_dir
 ORDER BY is_dir DESC, name ASC;
 
+-- name: ListExpiredObjects :many
+SELECT DISTINCT ON (object_key) object_key, backend_name, size_bytes, created_at
+FROM object_locations
+WHERE object_key LIKE @prefix::text || '%' ESCAPE '\'
+  AND created_at < @cutoff
+ORDER BY object_key, created_at ASC
+LIMIT @max_keys;
+
 -- name: ListDirectChildren :many
 -- Return per-file detail for non-directory children under a prefix, with pagination.
 SELECT DISTINCT ON (object_key) object_key, backend_name, size_bytes, created_at

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -379,6 +379,33 @@ var (
 		},
 	)
 
+	// --- Lifecycle metrics ---
+
+	// LifecycleDeletedTotal counts objects deleted by lifecycle expiration rules.
+	LifecycleDeletedTotal = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "s3proxy_lifecycle_deleted_total",
+			Help: "Objects deleted by lifecycle expiration rules",
+		},
+	)
+
+	// LifecycleFailedTotal counts objects that failed lifecycle deletion.
+	LifecycleFailedTotal = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "s3proxy_lifecycle_failed_total",
+			Help: "Objects that failed lifecycle deletion",
+		},
+	)
+
+	// LifecycleRunsTotal counts lifecycle worker executions.
+	LifecycleRunsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "s3proxy_lifecycle_runs_total",
+			Help: "Lifecycle worker executions",
+		},
+		[]string{"status"},
+	)
+
 	// --- Audit metrics ---
 
 	// AuditEventsTotal counts audit log entries by event type.

--- a/internal/testutil/mock_store.go
+++ b/internal/testutil/mock_store.go
@@ -291,6 +291,10 @@ func (m *MockStore) CleanupQueueDepth(_ context.Context) (int64, error) {
 	return 0, nil
 }
 
+func (m *MockStore) ListExpiredObjects(_ context.Context, _ string, _ time.Time, _ int) ([]storage.ObjectLocation, error) {
+	return nil, nil
+}
+
 func (m *MockStore) WithAdvisoryLock(_ context.Context, _ int64, fn func(ctx context.Context) error) (bool, error) {
 	return true, fn(context.Background())
 }

--- a/packaging/changelog
+++ b/packaging/changelog
@@ -1,3 +1,13 @@
+s3-orchestrator (0.6.6-1) stable; urgency=low
+
+  * Config-driven lifecycle rules for automatic object expiration
+  * Background worker deletes objects matching prefix + expiration_days
+  * Reuses existing DeleteObject path (quota, cleanup queue, all copies)
+  * Hot-reloadable via SIGHUP; no schema migration needed
+  * New metrics: lifecycle_deleted_total, lifecycle_failed_total, lifecycle_runs_total
+
+ -- Alex Freidah <alex.freidah@gmail.com>  Wed, 26 Feb 2026 00:00:00 +0000
+
 s3-orchestrator (0.6.5-1) stable; urgency=low
 
   * Optional parallel broadcast reads in degraded mode (circuit_breaker.parallel_broadcast)


### PR DESCRIPTION
  Prefix-based rules delete objects older than a configurable expiration
  period. Processes in batches of 100 with pagination, reusing the
  existing DeleteObject path for quota decrement and cleanup queue.