### PR TITLE
feat: add GoReleaser releases, Codecov, Dependabot, and CI badges

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,12 @@ jobs:
           go-version-file: go.mod
 
       - name: Unit tests
-        run: make test
+        run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.out
 
   integration:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Prep changelog
+        run: make prep-changelog
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,111 @@
+# -------------------------------------------------------------------------------
+# GoReleaser Configuration
+#
+# Produces GitHub Release artifacts on tag push: statically linked binaries,
+# Debian packages (via nfpm), and SHA256 checksums. Docker images are NOT
+# built here — the private registry is unreachable from GitHub Actions.
+# -------------------------------------------------------------------------------
+
+version: 2
+
+builds:
+  - main: ./cmd/s3-orchestrator
+    binary: s3-orchestrator
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w -X github.com/afreidah/s3-orchestrator/internal/telemetry.Version={{.Version}}
+
+archives:
+  - formats:
+      - tar.gz
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}
+
+nfpms:
+  - id: deb
+    package_name: s3-orchestrator
+    vendor: Munchbox
+    homepage: https://github.com/afreidah/s3-orchestrator
+    maintainer: Alex Freidah <alex.freidah@gmail.com>
+    description: |
+      Unified S3-compatible storage endpoint. Routes requests across multiple
+      S3 backends with quota management, replication, and usage tracking.
+    section: admin
+    priority: optional
+    formats:
+      - deb
+    dependencies:
+      - systemd
+    contents:
+      - src: ./packaging/s3-orchestrator.service
+        dst: /usr/lib/systemd/system/s3-orchestrator.service
+        file_info:
+          mode: 0644
+
+      - src: ./packaging/s3-orchestrator.default
+        dst: /etc/default/s3-orchestrator
+        type: config|noreplace
+        file_info:
+          mode: 0640
+
+      - dst: /etc/s3-orchestrator
+        type: dir
+        file_info:
+          mode: 0750
+
+      - src: ./packaging/config.yaml
+        dst: /etc/s3-orchestrator/config.yaml
+        type: config|noreplace
+        file_info:
+          mode: 0640
+
+      - dst: /var/lib/s3-orchestrator
+        type: dir
+        file_info:
+          mode: 0750
+
+      - src: ./packaging/copyright
+        dst: /usr/share/doc/s3-orchestrator/copyright
+        file_info:
+          mode: 0644
+
+      - src: ./packaging/changelog.gz
+        dst: /usr/share/doc/s3-orchestrator/changelog.Debian.gz
+        file_info:
+          mode: 0644
+
+      - src: ./packaging/lintian-overrides
+        dst: /usr/share/lintian/overrides/s3-orchestrator
+        file_info:
+          mode: 0644
+
+    scripts:
+      preinstall: ./packaging/preinstall.sh
+      postinstall: ./packaging/postinstall.sh
+      postremove: ./packaging/postremove.sh
+
+checksum:
+  name_template: checksums.txt
+
+changelog:
+  sort: asc
+  groups:
+    - title: Features
+      regexp: '^.*?feat(\(.+\))?\!?:.+$'
+      order: 0
+    - title: Bug Fixes
+      regexp: '^.*?fix(\(.+\))?\!?:.+$'
+      order: 1
+    - title: Other
+      order: 999
+
+release:
+  github:
+    owner: afreidah
+    name: s3-orchestrator

--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,13 @@ deb-all: ## Build .deb packages for amd64 and arm64
 	$(MAKE) deb DEB_ARCH=arm64
 
 # -------------------------------------------------------------------------
+# RELEASE
+# -------------------------------------------------------------------------
+
+release-local: prep-changelog ## Dry-run GoReleaser locally (no publish)
+	goreleaser release --snapshot --clean
+
+# -------------------------------------------------------------------------
 # CLEANUP
 # -------------------------------------------------------------------------
 
@@ -151,5 +158,5 @@ clean: ## Remove build artifacts and local image
 	rm -rf dist/ *.deb packaging/changelog.gz
 	docker rmi $(FULL_TAG) || true
 
-.PHONY: help builder build push generate test vet lint run integration-deps integration-test integration-clean tools prep-changelog deb deb-lint deb-all clean
+.PHONY: help builder build push generate test vet lint run integration-deps integration-test integration-clean tools prep-changelog deb deb-lint deb-all release-local clean
 .DEFAULT_GOAL := help

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # S3 Orchestrator
 
+[![CI](https://github.com/afreidah/s3-orchestrator/actions/workflows/ci.yml/badge.svg)](https://github.com/afreidah/s3-orchestrator/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/afreidah/s3-orchestrator/branch/main/graph/badge.svg)](https://codecov.io/gh/afreidah/s3-orchestrator)
+
 An S3-compatible orchestrator that combines multiple storage backends into a single unified endpoint. Add as many S3-compatible backends as you want — OCI Object Storage, Backblaze B2, AWS S3, MinIO, whatever — and the orchestrator presents them to clients as one or more virtual buckets. Per-backend quota enforcement lets you cap each backend at exactly the byte limit you choose, so you can stack multiple free-tier allocations from different providers into a single, larger storage target for backups, media, or anything else without worrying about surprise bills.
 
 Multiple virtual buckets let different applications share the same orchestrator with isolated file namespaces and independent credentials. Each bucket's objects are stored with an internal key prefix (`{bucket}/{key}`), so bucket isolation requires zero changes to the storage layer or database schema.
@@ -555,6 +558,9 @@ make deb-all VERSION=0.6.4
 
 # Build and run lintian validation
 make deb-lint VERSION=0.6.4
+
+# Dry-run GoReleaser locally (builds everything without publishing)
+make release-local
 ```
 
 ## Deployment
@@ -605,6 +611,29 @@ The package installs:
 | `/var/lib/s3-orchestrator/` | Data directory |
 
 The systemd unit runs as a dedicated `s3-orchestrator` user with filesystem hardening (`ProtectSystem=strict`, `ProtectHome=yes`, `NoNewPrivileges=yes`). Config reload via `systemctl reload s3-orchestrator` sends `SIGHUP`.
+
+### Releasing
+
+Tag a version and push to trigger an automated GitHub Release via GoReleaser:
+
+```bash
+git tag v0.7.0
+git push origin v0.7.0
+```
+
+This builds Linux binaries (amd64 + arm64), Debian packages, and SHA256 checksums — all attached to the GitHub Release with an auto-generated changelog.
+
+Docker images are still built manually since the private registry isn't reachable from GitHub Actions:
+
+```bash
+make push VERSION=v0.7.0
+```
+
+To dry-run the release locally (builds everything without publishing):
+
+```bash
+make release-local
+```
 
 ## Project Structure
 


### PR DESCRIPTION
  Automate GitHub Releases on tag push via GoReleaser (binaries, .debs,
  checksums for linux/amd64+arm64). Add Codecov coverage upload to CI,
  Dependabot for Go modules and Actions, and CI/coverage badges to README.