### PR TITLE
docs: close onboarding gaps for replication with encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ See the [Quickstart](docs/quickstart.md) for full details, credentials for all b
 - Debian: download `.deb` from [GitHub Releases](https://github.com/afreidah/s3-orchestrator/releases)
 - Binary: download from [GitHub Releases](https://github.com/afreidah/s3-orchestrator/releases)
 
+> **Requires PostgreSQL 14+.** The orchestrator stores object metadata, quotas, and replication state in PostgreSQL. The `make run` quickstart handles this automatically, but standalone installs need an existing PostgreSQL instance. Database tables are created automatically on first start.
+
 **Verify artifact signatures:**
 
 Container images and release checksums are signed with [cosign](https://github.com/sigstore/cosign) (keyless / Sigstore):
@@ -464,6 +466,20 @@ backends:
     api_request_limit: 0      # monthly API request limit (0 = unlimited)
     egress_byte_limit: 0      # monthly egress byte limit (0 = unlimited)
     ingress_byte_limit: 0     # monthly ingress byte limit (0 = unlimited)
+
+**Provider quick reference** — endpoint format and required flags for common S3-compatible providers:
+
+| Provider | Endpoint | `force_path_style` | Notes |
+|----------|----------|-------------------|-------|
+| AWS S3 | `https://s3.<region>.amazonaws.com` | `false` (default) | |
+| MinIO | `http://<host>:9000` | `true` | |
+| OCI Object Storage | `https://<ns>.compat.objectstorage.<region>.oraclecloud.com` | `true` | |
+| Backblaze B2 | `https://s3.<region>.backblazeb2.com` | `false` | |
+| Cloudflare R2 | `https://<account-id>.r2.cloudflarestorage.com` | `false` | `region: auto` |
+| Wasabi | `https://s3.<region>.wasabisys.com` | `false` | |
+| Google Cloud Storage | `https://storage.googleapis.com` | `false` | Set `disable_checksum: true` and `strip_sdk_headers: true` |
+
+See the [Maximizing Free Tiers](https://s3-orchestrator.munchbox.cc/guides/maximizing-free-tiers/) guide for detailed setup on each provider including where to find credentials.
 
 telemetry:
   metrics:

--- a/web/content/guides/minio-cloud-replication.md
+++ b/web/content/guides/minio-cloud-replication.md
@@ -119,6 +119,10 @@ When MinIO comes back online, the replication worker detects that objects writte
 
 No changes are needed on the MinIO side. It does not need to know about the orchestrator or the cloud backend.
 
+{{% notice info %}}
+**Encryption and replication:** If encryption is enabled, objects are encrypted before they are written to any backend. Replicas are copied as opaque ciphertext — the replicator does not decrypt and re-encrypt, it streams the encrypted bytes directly. All copies share the same encryption key metadata, so any copy can be decrypted by the orchestrator. Enabling or disabling encryption does not affect the replication process.
+{{% /notice %}}
+
 ## Monitoring Replication
 
 Track replication progress through the web dashboard or Prometheus metrics:
@@ -137,3 +141,25 @@ Replication copies count against the cloud backend's quota and usage limits. If 
 - The replicator is idempotent - restarting the orchestrator does not duplicate objects
 - To replicate to multiple cloud providers for extra safety, add more backends and increase the replication factor
 - If you have existing objects in MinIO, the orchestrator can discover and replicate them via the admin sync operation
+
+## Optional: Enable Encryption
+
+To encrypt all data before it leaves the orchestrator (so backends only ever store ciphertext), add an `encryption` section to your config:
+
+```yaml
+encryption:
+  enabled: true
+  master_key: "${ENCRYPTION_KEY}"
+```
+
+Generate a key with `openssl rand -base64 32` and store it securely.
+
+After restarting the orchestrator, all new writes are encrypted automatically. Both the primary copy on MinIO and the replica on the cloud backend are encrypted — backends never see plaintext.
+
+To encrypt objects that were uploaded before encryption was enabled, run:
+
+```bash
+s3-orchestrator admin encrypt-existing
+```
+
+For production deployments, consider using [Vault Transit](../nomad-vault-deployment/) instead of an inline key. See the [Encrypting Existing Data](../encrypting-existing-data/) guide for the full walkthrough and the [Key Rotation](../key-rotation/) guide for rotating master keys.


### PR DESCRIPTION
## Summary
- Add "Optional: Enable Encryption" section to minio-cloud-replication guide so
  users don't have to cross-reference a separate guide
- Add encryption + replication interaction callout explaining replicas are copied
  as ciphertext with no re-encryption
- Add provider quick reference table to README (AWS, MinIO, OCI, B2, R2, Wasabi,
  GCS) with endpoint format, `force_path_style`, and compatibility flags
- Add prominent PostgreSQL prerequisite note to README install section

Closes #501

## Test plan
- [x] Docs-only change, no code modified
- [ ] CI passes