### PR TITLE
ci: run SonarQube on non-Go PRs and clear remaining CSS contrast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [test, integration]
-    if: always() && needs.test.result == 'success'
+    # Run whenever the upstream test job did not fail. Skipped is fine
+    # (no Go changed, so no coverage produced); the scan still inspects
+    # CSS, JS, YAML, and any non-Go files in the diff.
+    if: always() && needs.test.result != 'failure' && needs.test.result != 'cancelled'
     steps:
       - uses: actions/checkout@v6
         with:
@@ -186,6 +189,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: unit-coverage
+        continue-on-error: true
 
       - name: Download integration coverage
         uses: actions/download-artifact@v8

--- a/internal/transport/ui/static/style.css
+++ b/internal/transport/ui/static/style.css
@@ -76,7 +76,7 @@ body {
 .login-card button:hover { background: #7dd3fc; }
 
 .login-error {
-  background: rgba(239, 68, 68, 0.15);
+  background: #451a1a;
   color: #fca5a5;
   padding: 0.5rem 0.75rem;
   border-radius: 0.35rem;
@@ -370,8 +370,8 @@ td.key {
 
 .tree-file:hover .tree-action { opacity: 1; }
 .tree-dir > summary:hover .tree-action { opacity: 1; }
-.tree-download:hover { color: #60a5fa; background: rgba(59, 130, 246, 0.1); }
-.tree-delete:hover { color: #f87171; background: rgba(239, 68, 68, 0.1); }
+.tree-download:hover { color: #60a5fa; background: #1e3a5f; }
+.tree-delete:hover { color: #f87171; background: #4a1d1d; }
 
 /* --- Dialog centering (all dialogs) --- */
 dialog {


### PR DESCRIPTION
## Summary
Two fixes bundled because they motivate each other.

### 1. SonarCloud no longer skips non-Go PRs
The \`sonarqube\` job in \`ci.yml\` was gated on \`needs.test.result == 'success'\`. When a PR touched only CSS/JS/YAML the \`test\` job was \`skipped\`, the gate evaluated to false, and the scan never ran - leaving SonarCloud counts stale until the next Go-touching PR.

Loosen the condition so the scan runs whenever \`test\` did not fail or get cancelled; \`skipped\` is now treated like success. Also makes the unit-coverage artifact download tolerate a missing artifact so the job still runs cleanly on non-Go PRs (no coverage, but the scan inspects CSS, JS, YAML, and any non-Go files in the diff).

### 2. Remaining \`css:S7924\` issues (3 left after PR #705)
Sonar cannot evaluate contrast through \`rgba()\` alpha-blending and conservatively flags any rule that uses one. Swap the three offenders to opaque hex equivalents that match what the rgba layers render to in the existing dark theme:

| Selector | Before | After |
|---|---|---|
| \`.login-error\` background | \`rgba(239,68,68,0.15)\` | \`#451a1a\` |
| \`.tree-download:hover\` background | \`rgba(59,130,246,0.1)\` | \`#1e3a5f\` |
| \`.tree-delete:hover\` background | \`rgba(239,68,68,0.1)\` | \`#4a1d1d\` |

Visual difference is negligible because the rgba renders to roughly those values once blended; the foreground colors picked in #705 already had >= 5:1 contrast against them.

## Test plan
- [x] \`make lint\` clean
- [x] \`make test\` passes
- [x] \`make integration-test\` passes
- [ ] CI green
- [ ] SonarCloud reports \`css:S7924\` drops to 0

Closes #704