### PR TITLE
WIP: Default to environment variables, sso, imds when running in AWS/ OpenStack aws-compatability mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.3
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.7
+	github.com/aws/aws-sdk-go-v2/config v1.32.17
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.16
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0
 	github.com/aws/smithy-go v1.25.1
@@ -39,6 +40,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24 // indirect
@@ -46,6 +48,10 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.23 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.23 // indirect
+	github.com/aws/aws-sdk-go-v2/service/signin v1.0.11 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sso v1.30.17 // indirect
+	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.21 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sts v1.42.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,12 @@ github.com/aws/aws-sdk-go-v2 v1.41.7 h1:DWpAJt66FmnnaRIOT/8ASTucrvuDPZASqhhLey6t
 github.com/aws/aws-sdk-go-v2 v1.41.7/go.mod h1:4LAfZOPHNVNQEckOACQx60Y8pSRjIkNZQz1w92xpMJc=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 h1:gx1AwW1Iyk9Z9dD9F4akX5gnN3QZwUB20GGKH/I+Rho=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10/go.mod h1:qqY157uZoqm5OXq/amuaBJyC9hgBCBQnsaWnPe905GY=
+github.com/aws/aws-sdk-go-v2/config v1.32.17 h1:FpL4/758/diKwqbytU0prpuiu60fgXKUWCpDJtApclU=
+github.com/aws/aws-sdk-go-v2/config v1.32.17/go.mod h1:OXqUMzgXytfoF9JaKkhrOYsyh72t9G+MJH8mMRaexOE=
 github.com/aws/aws-sdk-go-v2/credentials v1.19.16 h1:r3RJBuU7X9ibt8RHbMjWE6y60QbKBiII6wSrXnapxSU=
 github.com/aws/aws-sdk-go-v2/credentials v1.19.16/go.mod h1:6cx7zqDENJDbBIIWX6P8s0h6hqHC8Avbjh9Dseo27ug=
+github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.23 h1:UuSfcORqNSz/ey3VPRS8TcVH2Ikf0/sC+Hdj400QI6U=
+github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.23/go.mod h1:+G/OSGiOFnSOkYloKj/9M35s74LgVAdJBSD5lsFfqKg=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 h1:GpT/TrnBYuE5gan2cZbTtvP+JlHsutdmlV2YfEyNde0=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23/go.mod h1:xYWD6BS9ywC5bS3sz9Xh04whO/hzK2plt2Zkyrp4JuA=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 h1:bpd8vxhlQi2r1hiueOw02f/duEPTMK59Q4QMAoTTtTo=
@@ -35,6 +39,14 @@ github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.23 h1:03xatSQO4+AM1
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.23/go.mod h1:M8l3mwgx5ToK7wot2sBBce/ojzgnPzZXUV445gTSyE8=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0 h1:etqBTKY581iwLL/H/S2sVgk3C9lAsTJFeXWFDsDcWOU=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0/go.mod h1:L2dcoOgS2VSgbPLvpak2NyUPsO1TBN7M45Z4H7DlRc4=
+github.com/aws/aws-sdk-go-v2/service/signin v1.0.11 h1:TdJ+HdzOBhU8+iVAOGUTU63VXopcumCOF1paFulHWZc=
+github.com/aws/aws-sdk-go-v2/service/signin v1.0.11/go.mod h1:R82ZRExE/nheo0N+T8zHPcLRTcH8MGsnR3BiVGX0TwI=
+github.com/aws/aws-sdk-go-v2/service/sso v1.30.17 h1:7byT8HUWrgoRp6sXjxtZwgOKfhss5fW6SkLBtqzgRoE=
+github.com/aws/aws-sdk-go-v2/service/sso v1.30.17/go.mod h1:xNWknVi4Ezm1vg1QsB/5EWpAJURq22uqd38U8qKvOJc=
+github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.21 h1:+1Kl1zx6bWi4X7cKi3VYh29h8BvsCoHQEQ6ST9X8w7w=
+github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.21/go.mod h1:4vIRDq+CJB2xFAXZ+YgGUTiEft7oAQlhIs71xcSeuVg=
+github.com/aws/aws-sdk-go-v2/service/sts v1.42.1 h1:F/M5Y9I3nwr2IEpshZgh1GeHpOItExNM9L1euNuh/fk=
+github.com/aws/aws-sdk-go-v2/service/sts v1.42.1/go.mod h1:mTNxImtovCOEEuD65mKW7DCsL+2gjEH+RPEAexAzAio=
 github.com/aws/smithy-go v1.25.1 h1:J8ERsGSU7d+aCmdQur5Txg6bVoYelvQJgtZehD12GkI=
 github.com/aws/smithy-go v1.25.1/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/internal/backend/s3.go
+++ b/internal/backend/s3.go
@@ -25,15 +25,16 @@ import (
 	"strings"
 	"time"
 
+	"github.com/afreidah/s3-orchestrator/internal/config"
+	"github.com/afreidah/s3-orchestrator/internal/observe"
+	"github.com/afreidah/s3-orchestrator/internal/observe/telemetry"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	awsConfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	smithymiddleware "github.com/aws/smithy-go/middleware"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
-	"github.com/afreidah/s3-orchestrator/internal/config"
-	"github.com/afreidah/s3-orchestrator/internal/observe"
-	"github.com/afreidah/s3-orchestrator/internal/observe/telemetry"
 )
 
 // -------------------------------------------------------------------------
@@ -104,7 +105,7 @@ func newBackendTransport() *http.Transport {
 		IdleConnTimeout:       60 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ResponseHeaderTimeout: 30 * time.Second,
-		ForceAttemptHTTP2:      true,
+		ForceAttemptHTTP2:     true,
 	}
 }
 
@@ -115,10 +116,19 @@ func NewS3Backend(cfg *config.BackendConfig) (*S3Backend, error) {
 	// --- Create S3 client with custom endpoint and transport ---
 	opts := s3.Options{
 		Region:       cfg.Region,
-		Credentials:  credentials.NewStaticCredentialsProvider(cfg.AccessKeyID, cfg.SecretAccessKey, ""),
 		BaseEndpoint: aws.String(cfg.Endpoint),
 		UsePathStyle: cfg.ForcePathStyle,
 		HTTPClient:   &http.Client{Transport: newBackendTransport()},
+	}
+	if cfg.AccessKeyID != "" && cfg.SecretAccessKey != "" {
+		opts.Credentials = credentials.NewStaticCredentialsProvider(cfg.AccessKeyID, cfg.SecretAccessKey, "")
+	} else {
+		defaultCfg, err := awsConfig.LoadDefaultConfig(context.TODO())
+		if err != nil {
+			return nil, err
+		}
+
+		opts.Credentials = defaultCfg.Credentials
 	}
 	if cfg.DisableChecksum {
 		opts.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired

--- a/internal/config/backends.go
+++ b/internal/config/backends.go
@@ -16,21 +16,21 @@ import "fmt"
 
 // BackendConfig holds configuration for an S3-compatible storage backend.
 type BackendConfig struct {
-	Name            string `yaml:"name"`              // Identifier for metrics/tracing
-	Endpoint        string `yaml:"endpoint"`          // S3-compatible endpoint URL
-	Region          string `yaml:"region"`            // AWS region or equivalent
-	Bucket          string `yaml:"bucket"`            // Target bucket name
-	AccessKeyID     string `yaml:"access_key_id"`     // AWS access key ID
-	SecretAccessKey string `yaml:"secret_access_key"` // AWS secret access key
-	ForcePathStyle   bool  `yaml:"force_path_style"`   // Use path-style URLs
-	UnsignedPayload  *bool `yaml:"unsigned_payload"`   // Skip SigV4 payload hash to stream uploads without buffering (default: true)
-	DisableChecksum  bool  `yaml:"disable_checksum"`   // Disable SDK default checksums for GCS and other providers that reject them (default: false)
-	StripSDKHeaders  bool  `yaml:"strip_sdk_headers"`  // Remove SDK v2 headers (amz-sdk-*, accept-encoding, x-id) before signing for GCS compatibility (default: false)
-	QuotaBytes       int64 `yaml:"quota_bytes"`        // Maximum bytes allowed on this backend (0 = unlimited)
-	MaxObjectSize    int64 `yaml:"max_object_size"`    // Maximum size of a single object in bytes (0 = unlimited)
-	APIRequestLimit  int64 `yaml:"api_request_limit"`  // Monthly API request limit (0 = unlimited)
-	EgressByteLimit  int64 `yaml:"egress_byte_limit"`  // Monthly egress byte limit (0 = unlimited)
-	IngressByteLimit int64 `yaml:"ingress_byte_limit"` // Monthly ingress byte limit (0 = unlimited)
+	Name             string `yaml:"name"`               // Identifier for metrics/tracing
+	Endpoint         string `yaml:"endpoint"`           // S3-compatible endpoint URL
+	Region           string `yaml:"region"`             // AWS region or equivalent
+	Bucket           string `yaml:"bucket"`             // Target bucket name
+	AccessKeyID      string `yaml:"access_key_id"`      // AWS access key ID
+	SecretAccessKey  string `yaml:"secret_access_key"`  // AWS secret access key
+	ForcePathStyle   bool   `yaml:"force_path_style"`   // Use path-style URLs
+	UnsignedPayload  *bool  `yaml:"unsigned_payload"`   // Skip SigV4 payload hash to stream uploads without buffering (default: true)
+	DisableChecksum  bool   `yaml:"disable_checksum"`   // Disable SDK default checksums for GCS and other providers that reject them (default: false)
+	StripSDKHeaders  bool   `yaml:"strip_sdk_headers"`  // Remove SDK v2 headers (amz-sdk-*, accept-encoding, x-id) before signing for GCS compatibility (default: false)
+	QuotaBytes       int64  `yaml:"quota_bytes"`        // Maximum bytes allowed on this backend (0 = unlimited)
+	MaxObjectSize    int64  `yaml:"max_object_size"`    // Maximum size of a single object in bytes (0 = unlimited)
+	APIRequestLimit  int64  `yaml:"api_request_limit"`  // Monthly API request limit (0 = unlimited)
+	EgressByteLimit  int64  `yaml:"egress_byte_limit"`  // Monthly egress byte limit (0 = unlimited)
+	IngressByteLimit int64  `yaml:"ingress_byte_limit"` // Monthly ingress byte limit (0 = unlimited)
 }
 
 // validateBackends checks every BackendConfig in the configured list,
@@ -82,11 +82,8 @@ func requiredBackendStringErrs(prefix string, b *BackendConfig) []error {
 	if b.Bucket == "" {
 		errs = append(errs, prefixed(prefix, ErrBackendBucketReqd))
 	}
-	if b.AccessKeyID == "" {
-		errs = append(errs, prefixed(prefix, ErrAccessKeyIDReqd))
-	}
-	if b.SecretAccessKey == "" {
-		errs = append(errs, prefixed(prefix, ErrSecretAccessKeyReqd))
+	if (b.AccessKeyID == "" && b.SecretAccessKey != "") || (b.SecretAccessKey == "" && b.AccessKeyID != "") {
+		errs = append(errs, prefixed(prefix, ErrAccessKeySecretKeySet))
 	}
 	return errs
 }

--- a/internal/config/errors.go
+++ b/internal/config/errors.go
@@ -4,7 +4,7 @@
 // Author: Alex Freidah
 //
 // Config validators previously returned errors as joined strings, forcing
-// tests to match on substrings. That made error messages de-facto APIs  - 
+// tests to match on substrings. That made error messages de-facto APIs  -
 // a harmless reword would silently break test assertions.
 //
 // Each validator now wraps a sentinel defined below using fmt.Errorf("%w:
@@ -62,17 +62,16 @@ var (
 
 // Backend validation errors.
 var (
-	ErrNoBackends          = errors.New("at least one backend is required")
-	ErrDuplicateBackend    = errors.New("duplicate backend name")
-	ErrEndpointRequired    = errors.New("endpoint is required")
-	ErrBackendBucketReqd   = errors.New("bucket is required")
-	ErrAccessKeyIDReqd     = errors.New("access_key_id is required")
-	ErrSecretAccessKeyReqd = errors.New("secret_access_key is required")
-	ErrNegativeQuota       = errors.New("quota_bytes must not be negative")
-	ErrNegativeMaxObject   = errors.New("max_object_size must not be negative")
-	ErrNegativeAPILimit    = errors.New("api_request_limit must not be negative")
-	ErrNegativeEgress      = errors.New("egress_byte_limit must not be negative")
-	ErrNegativeIngress     = errors.New("ingress_byte_limit must not be negative")
+	ErrNoBackends            = errors.New("at least one backend is required")
+	ErrDuplicateBackend      = errors.New("duplicate backend name")
+	ErrEndpointRequired      = errors.New("endpoint is required")
+	ErrBackendBucketReqd     = errors.New("bucket is required")
+	ErrAccessKeySecretKeySet = errors.New("access_key_id and secret_access_key must either be both set, or both unset")
+	ErrNegativeQuota         = errors.New("quota_bytes must not be negative")
+	ErrNegativeMaxObject     = errors.New("max_object_size must not be negative")
+	ErrNegativeAPILimit      = errors.New("api_request_limit must not be negative")
+	ErrNegativeEgress        = errors.New("egress_byte_limit must not be negative")
+	ErrNegativeIngress       = errors.New("ingress_byte_limit must not be negative")
 )
 
 // Server and TLS errors.
@@ -90,25 +89,25 @@ var (
 
 // Rate limit errors.
 var (
-	ErrInvalidCIDR                 = errors.New("invalid CIDR in trusted_proxies")
-	ErrRateLimitRPSNotPositive     = errors.New("rate_limit.requests_per_sec must be positive")
-	ErrRateLimitBurstNotPositive   = errors.New("rate_limit.burst must be positive")
+	ErrInvalidCIDR               = errors.New("invalid CIDR in trusted_proxies")
+	ErrRateLimitRPSNotPositive   = errors.New("rate_limit.requests_per_sec must be positive")
+	ErrRateLimitBurstNotPositive = errors.New("rate_limit.burst must be positive")
 )
 
 // Encryption errors.
 var (
-	ErrInvalidChunkSize         = errors.New("encryption.chunk_size must be between 4096 (4KB) and 1048576 (1MB)")
-	ErrChunkSizeNotPowerOf2     = errors.New("encryption.chunk_size must be a power of 2")
-	ErrKeySourceRequired        = errors.New("encryption: exactly one of master_key, master_key_file, or vault is required")
-	ErrMultipleKeySources       = errors.New("encryption: only one of master_key, master_key_file, or vault may be set")
-	ErrInvalidBase64Key         = errors.New("invalid base64 key material")
-	ErrInvalidKeyLength         = errors.New("key must be 256 bits (32 bytes)")
-	ErrInvalidKeyFile           = errors.New("invalid master_key_file")
-	ErrPreviousKeyInvalid       = errors.New("previous_keys entry invalid")
-	ErrVaultAddressRequired     = errors.New("encryption.vault.address is required")
-	ErrVaultTokenRequired       = errors.New("encryption.vault: one of token or token_file is required")
-	ErrVaultTokenAmbiguous      = errors.New("encryption.vault: only one of token or token_file may be set")
-	ErrVaultKeyNameRequired     = errors.New("encryption.vault.key_name is required")
+	ErrInvalidChunkSize     = errors.New("encryption.chunk_size must be between 4096 (4KB) and 1048576 (1MB)")
+	ErrChunkSizeNotPowerOf2 = errors.New("encryption.chunk_size must be a power of 2")
+	ErrKeySourceRequired    = errors.New("encryption: exactly one of master_key, master_key_file, or vault is required")
+	ErrMultipleKeySources   = errors.New("encryption: only one of master_key, master_key_file, or vault may be set")
+	ErrInvalidBase64Key     = errors.New("invalid base64 key material")
+	ErrInvalidKeyLength     = errors.New("key must be 256 bits (32 bytes)")
+	ErrInvalidKeyFile       = errors.New("invalid master_key_file")
+	ErrPreviousKeyInvalid   = errors.New("previous_keys entry invalid")
+	ErrVaultAddressRequired = errors.New("encryption.vault.address is required")
+	ErrVaultTokenRequired   = errors.New("encryption.vault: one of token or token_file is required")
+	ErrVaultTokenAmbiguous  = errors.New("encryption.vault: only one of token or token_file may be set")
+	ErrVaultKeyNameRequired = errors.New("encryption.vault.key_name is required")
 )
 
 // Redis / counter errors.
@@ -133,24 +132,24 @@ var (
 
 // Rebalance / replication errors.
 var (
-	ErrInvalidRebalanceStrategy  = errors.New("rebalance.strategy must be 'pack' or 'spread'")
-	ErrRebalanceIntervalNotPos   = errors.New("rebalance.interval must be positive")
-	ErrRebalanceBatchNotPos      = errors.New("rebalance.batch_size must be positive")
-	ErrRebalanceThresholdRange   = errors.New("rebalance.threshold must be between 0 and 1")
+	ErrInvalidRebalanceStrategy   = errors.New("rebalance.strategy must be 'pack' or 'spread'")
+	ErrRebalanceIntervalNotPos    = errors.New("rebalance.interval must be positive")
+	ErrRebalanceBatchNotPos       = errors.New("rebalance.batch_size must be positive")
+	ErrRebalanceThresholdRange    = errors.New("rebalance.threshold must be between 0 and 1")
 	ErrRebalanceConcurrencyNotPos = errors.New("rebalance.concurrency must be positive")
-	ErrReplicationFactorMin      = errors.New("replication.factor must be at least 1")
-	ErrReplicationFactorTooLarge = errors.New("replication.factor exceeds number of backends")
-	ErrReplicationIntervalNotPos = errors.New("replication.worker_interval must be positive")
-	ErrReplicationBatchNotPos    = errors.New("replication.batch_size must be positive")
-	ErrInvalidRoutingStrategy    = errors.New("routing_strategy must be 'pack' or 'spread'")
-	ErrQuotaMixNotAllowed        = errors.New("cannot mix unlimited (quota_bytes: 0) and quota-limited backends")
-	ErrUnlimitedNeedsReplication = errors.New("multiple backends with unlimited quota require replication.factor >= 2")
+	ErrReplicationFactorMin       = errors.New("replication.factor must be at least 1")
+	ErrReplicationFactorTooLarge  = errors.New("replication.factor exceeds number of backends")
+	ErrReplicationIntervalNotPos  = errors.New("replication.worker_interval must be positive")
+	ErrReplicationBatchNotPos     = errors.New("replication.batch_size must be positive")
+	ErrInvalidRoutingStrategy     = errors.New("routing_strategy must be 'pack' or 'spread'")
+	ErrQuotaMixNotAllowed         = errors.New("cannot mix unlimited (quota_bytes: 0) and quota-limited backends")
+	ErrUnlimitedNeedsReplication  = errors.New("multiple backends with unlimited quota require replication.factor >= 2")
 )
 
 // Usage flush / adaptive errors.
 var (
-	ErrUsageFlushFastInterval    = errors.New("usage_flush.fast_interval must be less than interval")
-	ErrUsageFlushThresholdRange  = errors.New("usage_flush.adaptive_threshold must be between 0 and 1")
+	ErrUsageFlushFastInterval   = errors.New("usage_flush.fast_interval must be less than interval")
+	ErrUsageFlushThresholdRange = errors.New("usage_flush.adaptive_threshold must be between 0 and 1")
 )
 
 // Cache / storage misc.


### PR DESCRIPTION
The current solution requires me to persist some long-lived credentials for accessing an S3 compatible endpoint, especially in AWS.

In my usecase, though, I am running the s3-orchestrator on AWS instances where I want to use the IMDS. And when I run locally to test, I want to be able to use my SSO credentials. Thus, when the AccessKeyID and SecretAccessKey are unset, I want to use the default AWS credentials chain.

For my specific use-case I am using the s3-orchestrator as a proxy to a set of S3 buckets on my VPN to allow iot devices to upload data without needing to distribute long-lived credentials, or credentials where rotation is onerous.

However, I understand that making this change might open the flood gates to other credential provider chains, and that this may require a larger architectural change. In which case, I am happy for my PR to be rejected, and to maintain my  own fork for my own usecase.

## Summary

<!-- Brief description of what this PR does and why. -->

## Related Issue

<!-- Link to the GitHub issue, e.g., Closes #123 -->

## Changes

-

## Testing

- [ ] Unit tests pass (`make test`)
- [ ] Integration tests pass (`make integration-test`)
- [ ] Linter passes (`make lint`)
- [ ] Manual testing performed (describe below if applicable)

## Notes

<!-- Anything reviewers should know: breaking changes, migration steps, etc. -->
