### PR TITLE
GH_ISSUE_878: docs audit sync — bring every doc in line with current code

### DIFF
--- a/README.md
+++ b/README.md
@@ -821,11 +821,15 @@ All metrics are prefixed with `s3o_`. Exposed at `/metrics` when enabled.
 | `s3o_usage_ingress_bytes` | Gauge | backend | Current month ingress bytes |
 | `s3o_usage_limit_rejections_total` | Counter | operation, limit_type | Operations rejected by usage limits |
 | `s3o_cleanup_queue_enqueued_total` | Counter | reason | Items added to the cleanup retry queue |
-| `s3o_cleanup_queue_processed_total` | Counter | status | Items processed from the cleanup queue (success/retry/exhausted) |
+| `s3o_cleanup_queue_processed_total` | Counter | status | Items processed from the cleanup queue (success/success_absent/retry/exhausted) — `success_absent` means the backend DELETE returned 404 and the row was dropped as idempotent success |
 | `s3o_cleanup_queue_depth` | Gauge | — | Current pending items in the cleanup queue |
+| `s3o_cleanup_queue_stale_claims_recovered_total` | Counter | backend | cleanup_queue rows whose stale claim was reclaimed by a later worker tick (worker died mid-process or grace period too short) |
 | `s3o_cleanup_dlq_depth` | Gauge | — | Unrecoverable orphans waiting in the cleanup dead-letter table |
 | `s3o_cleanup_dlq_enqueued_total` | Counter | backend | Cleanup rows graduated to the dead-letter after exhausting retries |
 | `s3o_cleanup_enqueue_failures_total` | Counter | backend, reason, stage | Cleanup-queue enqueue attempts that failed after a successful backend write (untracked-orphan risk) |
+| `s3o_pending_intents_enqueued_total` | Counter | — | In-flight PUT intents inserted before the backend write (PUT-before-COMMIT crash-recovery pattern) |
+| `s3o_pending_intents_resolved_total` | Counter | status | Pending PUT intents resolved by status (committed, promoted, dropped, ambiguous, already_resolved) |
+| `s3o_pending_intents_depth` | Gauge | — | Current number of unresolved pending PUT intents |
 | `s3o_rate_limit_rejections_total` | Counter | — | Requests rejected by per-IP rate limiting |
 | `s3o_admission_rejections_total` | Counter | — | Requests rejected by server-level admission control |
 | `s3o_list_pages_capped_total` | Counter | — | ListObjects calls that exited at the per-request page cap with more pages remaining |
@@ -836,9 +840,10 @@ All metrics are prefixed with `s3o_`. Exposed at `/metrics` when enabled.
 | `s3o_worker_last_success_timestamp_seconds` | Gauge | service | Unix time of the most recent successful tick per service |
 | `s3o_worker_consecutive_failures` | Gauge | service | Consecutive failed ticks per service since the last success |
 | `s3o_audit_events_total` | Counter | event | Audit log entries emitted |
-| `s3o_drain_active` | Gauge | — | `1` while a backend drain is in progress |
+| `s3o_drain_active` | Gauge | — | Count of in-flight backend drain operations (Inc/Dec so concurrent drains compose); 0 means no drains are running |
 | `s3o_drain_objects_moved_total` | Counter | — | Objects migrated during drain |
 | `s3o_drain_bytes_moved_total` | Counter | — | Bytes migrated during drain |
+| `s3o_drain_race_aborted_total` | Counter | — | PutObject attempts aborted after drain started mid-write (bytes are cleaned up and the attempt fails over to another backend) |
 | `s3o_encryption_operations_total` | Counter | op | Encrypt/decrypt operations (encrypt, decrypt, decrypt_range) |
 | `s3o_encryption_errors_total` | Counter | op, error_type | Encryption/decryption failures |
 | `s3o_encryption_unknown_key_id_total` | Counter | — | Decryption attempts with unknown keyID (primary key fallback) |
@@ -994,6 +999,8 @@ JSON APIs are available at `{path}/api/dashboard`, `{path}/api/tree`, and `{path
 | Path | Method | Purpose |
 |---|---|---|
 | `/admin/api/status` | GET | Backend health, quota, circuit-breaker state |
+| `/admin/api/reload-status` | GET | Most recent config reload result + generation |
+| `/admin/api/workers` | GET | Background worker health snapshot (cleanup, replicator, pending reaper, lifecycle, scrubber) |
 | `/admin/api/object-locations?key=...` | GET | Per-backend ledger for one object key |
 | `/admin/api/cleanup-queue` | GET | Cleanup queue depth and pending sample |
 | `/admin/api/usage-flush` | POST | Force out-of-band flush of usage counters |

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -380,13 +380,16 @@ Replication is **asynchronous** — writes go to a single backend and the replic
 
 ### Cleanup Queue
 
-The cleanup queue is always active. Two tunables apply:
+The cleanup queue is always active. Tunables:
 
 ```yaml
 cleanup_queue:
   concurrency: 10                # parallel cleanup deletions per tick (default: 10)
   claim_grace_period: 5m         # reclaim stale per-row claims older than this (default: 5m)
+  multipart_stale_timeout: 24h   # abort multipart uploads older than this (default: 24h)
 ```
+
+`multipart_stale_timeout` is consumed by the hourly `CleanupStaleMultipartUploads` sweep — uploads that have been open longer than this are aborted, their parts deleted from the backend, and the multipart rows removed. The default 24h matches the AWS S3 SDK's default abort behavior; lower it on backends with tight free-tier headroom to recover quota faster.
 
 When any backend object deletion fails during normal operations (PutObject orphan cleanup, DeleteObject, overwrite displaced copies, multipart part cleanup, rebalancer, replicator), the failed deletion is automatically enqueued for retry.
 
@@ -400,6 +403,7 @@ The background worker runs every minute and retries with exponential backoff (1 
 
 - `s3o_cleanup_queue_depth` staying elevated — orphaned objects are accumulating in the active queue.
 - `s3o_cleanup_queue_processed_total{status="exhausted"}` — counter increments each time an item exhausts retries.
+- `s3o_cleanup_queue_processed_total{status="success_absent"}` — counter increments each time a backend DELETE returned 404 and the row was dropped as idempotent success (the backend already agrees the object is gone). A sustained rate here is benign and just means upstream PUTs are silently failing somewhere; spikes are worth correlating with backend health.
 - `s3o_cleanup_queue_stale_claims_recovered_total{backend}` — non-zero rate means a worker died mid-process or the grace period is too short for realistic worst-case processing time.
 - `s3o_cleanup_dlq_depth > 0` — the DLQ holds at least one unrecoverable orphan; alerting here gives operators a direct signal instead of a counter delta.
 - `s3o_cleanup_dlq_enqueued_total{backend}` — rate of graduations per backend; a single backend dominating means that backend's delete path is broken.
@@ -437,6 +441,37 @@ SELECT backend_name, object_key, reason, size_bytes, NOW(), 0, last_error
   FROM cleanup_dlq WHERE id = 42;
 DELETE FROM cleanup_dlq WHERE id = 42;
 ```
+
+### write_path
+
+The write path can run in two modes. **Direct mode** (`enabled: false`) writes to the backend and commits the metadata immediately afterward; a crash between the two leaks bytes onto the backend with no DB record. **Pending-intent mode** (`enabled: true`, the default) inserts a row into `pending_objects` *before* the backend PUT and atomically deletes that row when the metadata commits — so a crash between the PUT and the commit leaves a recoverable intent the background reaper can resolve.
+
+```yaml
+write_path:
+  pending_pattern:
+    enabled: true        # default: true; PUT-before-COMMIT crash-recovery pattern
+    reaper_tick: 1m      # how often PendingReaper sweeps unresolved intents (default: 1m)
+    min_age: 5m          # only intents older than this are eligible (default: 5m) — avoids racing in-flight PUTs
+    batch_size: 50       # rows claimed per tick (default: 50)
+```
+
+**How recovery works.** On every tick the `PendingReaper` worker (`internal/worker/pending.go`) claims a batch of `pending_objects` rows older than `min_age`, HEADs the backend at the recorded key, and resolves each one:
+
+- **HEAD 200** → the backend received the bytes. Promote the intent to a committed `object_locations` row (`pending_reaper.promoted` audit event).
+- **HEAD 404** → the backend never received the bytes. Drop the intent (`pending_reaper.dropped` audit event). No orphan exists.
+- **Non-404 HEAD error** → leave the intent for the next tick. A sustained backend reachability problem here surfaces as `s3o_pending_intents_resolved_total{status="ambiguous"}`.
+- **A later write for the same key already committed** → drop the intent as superseded (`pending_reaper.superseded`).
+
+**Why `min_age` matters.** The reaper must not race the foreground write path; if `min_age` is too short the reaper can interrogate an intent whose backend PUT is still in flight and either prematurely commit it or churn `ambiguous` resolutions. The 5-minute default is generous; lower it only if you have measured the p99 PUT duration and accept the operational tradeoff.
+
+**Monitoring:**
+
+- `s3o_pending_intents_enqueued_total` — should track the PutObject rate closely.
+- `s3o_pending_intents_resolved_total{status}` — `committed` is the happy path (synchronous commit succeeded); `promoted` + `dropped` are reaper resolutions; `ambiguous` is the alert.
+- `s3o_pending_intents_depth` — gauge of unresolved intents. Alert when consistently above `batch_size` — the reaper is not keeping up (raise `batch_size`, lower `reaper_tick`, or add concurrency).
+- Audit events: `pending_reaper.promoted` / `pending_reaper.dropped` / `pending_reaper.superseded`.
+
+**When to disable.** Don't, unless you are running an embedded SQLite single-instance demo and trust the OS to flush. The pattern adds one DB write per PUT (cheap) and saves you from one entire class of write-path crash leak.
 
 ### rate_limit
 
@@ -1027,19 +1062,19 @@ Two health endpoints serve different purposes:
 
 ```bash
 curl http://localhost:9000/health
-# {"status":"ok","instance":"hostname"}
-# or {"status":"degraded","instance":"hostname"} when circuit breaker is open
+# {"status":"ok"}
+# or {"status":"degraded"} when the database circuit breaker is open
 ```
 
 **Readiness** (`/health/ready`) — returns HTTP 200 when the service is ready to handle traffic, HTTP 503 during startup (before migrations and backend initialization complete) and during shutdown drain. Use this for readiness probes (K8s readinessProbe, Nomad `on_update = "require_healthy"`).
 
 ```bash
 curl http://localhost:9000/health/ready
-# {"status":"ready","instance":"hostname"}      — 200
-# {"status":"not ready","instance":"hostname"}  — 503
+# {"status":"ready"}      — 200
+# {"status":"not ready"}  — 503
 ```
 
-Both endpoints include an `instance` field with the hostname for identifying which instance responded in multi-instance deployments.
+The HTTP response body is intentionally minimal — only the `status` field is returned, so log aggregators can grep on a fixed pattern. To identify which instance answered a probe in a multi-instance deployment, query `GET /admin/api/workers` (which includes the instance identifier) or correlate by source IP.
 
 ### Background worker health
 
@@ -1118,6 +1153,11 @@ If `telemetry.metrics.enabled` is `true`, metrics are exposed at `/metrics`. Key
 | `s3o_cleanup_queue_stale_claims_recovered_total{backend="..."}` | Non-zero rate means a worker died mid-process or `cleanup_queue.claim_grace_period` is shorter than realistic worst-case row processing time |
 | `s3o_cleanup_enqueue_failures_total{backend,reason,stage}` | Alert on any non-zero rate of `stage="enqueue"` — backend object exists with no `cleanup_queue` row (orphan-leak risk). Pivot via the matching `storage.OrphanEnqueueFailed` audit event for backend/key/size, then run `POST /admin/api/reconcile` after DB recovery |
 | `s3o_audit_events_total{event="..."}` | Audit log volume by event type — useful for detecting unusual activity |
+| `s3o_pending_intents_enqueued_total` | Rate of PUT intents inserted (write-path PUT-before-COMMIT pattern). Should track the PutObject rate closely; a sustained gap suggests the pending pattern is bypassed |
+| `s3o_pending_intents_resolved_total{status}` | Pending intents resolved by status (`committed` = atomic commit happy path, `promoted` = reaper found backend object and promoted the intent, `dropped` = reaper found HEAD 404 and dropped the intent, `ambiguous` = HEAD failed for non-404 reasons, `already_resolved` = race). A sustained `ambiguous` rate means the reaper cannot reach the backend |
+| `s3o_pending_intents_depth` | Current unresolved intents. Alert when consistently above the `batch_size` of the reaper — the reaper is not keeping up |
+| `s3o_drain_active` | Count of in-flight backend drain operations (Inc/Dec so concurrent drains compose); 0 means no drains are running. Page on `s3o_drain_active > 0 for 6h` (drain stuck) |
+| `s3o_drain_race_aborted_total` | PutObject attempts aborted after drain started mid-write. Any non-zero rate is benign (the orchestrator recovers automatically) but a sustained rate suggests longer-than-expected gaps between `EligibleForWrite` and the backend PUT — typically very large objects against a fast-draining backend |
 | `time() - s3o_worker_last_success_timestamp_seconds{service="..."}` | Alert when greater than the worker's expected tick interval times a margin (e.g. `> 4 * interval`) — the service has not completed a successful tick in that window |
 | `s3o_worker_consecutive_failures{service="..."}` | Alert when consistently > 0 — the service is running but every tick fails; logs and `/admin/api/workers` carry the underlying error |
 | `rate(s3o_worker_ticks_total{result="error"}[15m])` | Persistent error rate; alongside `consecutive_failures` distinguishes flapping from sustained failure |
@@ -1149,14 +1189,289 @@ Key audit events:
 | `replication.start`, `replication.copy`, `replication.complete` | Replicator | Replica creation runs |
 | `storage.MultipartCleanup` | Multipart cleanup | Stale upload cleanup |
 | `cleanup_queue.processed` | Cleanup queue | Orphaned object successfully deleted on retry |
+| `cleanup_queue.already_absent` | Cleanup queue | Backend DELETE returned 404 — the object is already gone. Row dropped as idempotent success instead of retrying nine more times |
 | `cleanup_queue.claim_recovered` | Cleanup queue | A row whose claim aged past the grace period was reclaimed by a different worker tick (typical after a process crash or rolling-deploy overlap) |
 | `cleanup_queue.exhausted_to_dlq` | Cleanup queue | Row graduated to `cleanup_dlq` after exhausting retries |
+| `over_replication.start`, `over_replication.complete`, `over_replication.remove` | Over-replication cleaner | Surplus replica removal cycle; `.remove` carries the per-copy decision |
+| `pending_reaper.promoted` | Pending reaper | The reaper HEADed the backend, found the object, and promoted the pending intent into a committed `object_locations` row |
+| `pending_reaper.dropped` | Pending reaper | The reaper HEADed the backend and got 404. No orphan exists; the intent row is dropped |
+| `pending_reaper.superseded` | Pending reaper | A later write for the same key completed and superseded the pending intent before the reaper resolved it |
+| `storage.OrphanEnqueueFailed` | Coordinator | The cleanup-queue enqueue path itself failed after a successful backend write (DB outage). Carries backend / key / size / stage so an operator can reconcile manually once DB connectivity returns |
+| `storage.UploadPart` | Multipart | A multipart part upload completed successfully |
 
 Each S3 API request produces two correlated audit entries (HTTP-level and storage-level) sharing the same `request_id`. Internal operations (rebalance, replication) generate their own correlation IDs. The `request_id` also appears as a `s3o.request_id` attribute on OpenTelemetry spans.
 
 Clients can supply their own correlation ID via the `X-Request-Id` request header; otherwise the orchestrator generates one. The ID is returned in the `X-Amz-Request-Id` response header.
 
 **Trace-to-log correlation** — JSON log output includes `trace_id` and `span_id` fields on every line emitted within an active OpenTelemetry span. Log aggregators like Grafana Loki can extract these fields to link directly from a log entry to the corresponding trace in Tempo, and vice versa.
+
+## Admin API Reference
+
+All `/admin/api/*` endpoints require the `X-Admin-Token` header. Set the token via the `S3O_ADMIN_TOKEN` environment variable or the `admin.token` config key. All request and response bodies are JSON; request bodies are capped at 1 MiB.
+
+Common error responses are documented under each section; for any unexpected server-side failure the response is `{"error": "<short message>"}` with HTTP 500 and the original error is logged with the request_id.
+
+### Health & status
+
+#### `GET /admin/api/status`
+
+Backend health snapshot: per-backend bytes used, bytes limit, object count, API requests, egress, ingress, plus the database circuit-breaker state.
+
+```bash
+curl -H "X-Admin-Token: $TOKEN" http://localhost:9000/admin/api/status
+```
+
+Response (200):
+
+```json
+{
+  "db_healthy": true,
+  "backends": [
+    {
+      "name": "oci",
+      "bytes_used": 12345678,
+      "bytes_limit": 10737418240,
+      "object_count": 4231,
+      "api_requests": 18234,
+      "egress_bytes": 92340876,
+      "ingress_bytes": 12345678
+    }
+  ],
+  "usage_period": "2026-05"
+}
+```
+
+#### `GET /admin/api/reload-status`
+
+Most recent config-reload result. Returns `{"status": "no_reload_yet"}` on a freshly started instance that has not yet had a SIGHUP. After a reload, returns the structured result (generation, summary of diffs, validation outcome, errors).
+
+```bash
+curl -H "X-Admin-Token: $TOKEN" http://localhost:9000/admin/api/reload-status
+```
+
+#### `GET /admin/api/workers`
+
+JSON snapshot of every registered background service's last-tick state. See [Background worker health](#background-worker-health) above for the response schema and full operator workflow. Returns 503 when the lifecycle manager is not wired (proxy-only deployments).
+
+#### `GET /admin/api/log-level` &middot; `PUT /admin/api/log-level`
+
+Inspect or change the runtime log level without restarting. Accepted levels: `debug`, `info`, `warn`, `error`.
+
+```bash
+curl -H "X-Admin-Token: $TOKEN" http://localhost:9000/admin/api/log-level
+# {"level":"info"}
+
+curl -X PUT -H "X-Admin-Token: $TOKEN" -H "Content-Type: application/json" \
+  -d '{"level":"debug"}' \
+  http://localhost:9000/admin/api/log-level
+# {"level":"debug"}
+```
+
+The change is logged via an `INFO` audit entry. Useful during incidents — flip to `debug` for a minute, capture the failure mode, then flip back.
+
+### Object inspection
+
+#### `GET /admin/api/object-locations?key=<key>`
+
+Returns all backend copies of a single object key, with backend name, size, and encryption metadata. Useful for debugging "where did this object actually land?" and for verifying that the replication factor is satisfied.
+
+```bash
+curl -H "X-Admin-Token: $TOKEN" "http://localhost:9000/admin/api/object-locations?key=reports/2026-05.pdf"
+```
+
+`400` when `key` is missing.
+
+### Cleanup & quota
+
+#### `GET /admin/api/cleanup-queue`
+
+Current cleanup queue depth plus a sample of up to 50 pending rows. The web dashboard's cleanup panel uses this endpoint.
+
+```bash
+curl -H "X-Admin-Token: $TOKEN" http://localhost:9000/admin/api/cleanup-queue
+```
+
+Response includes `depth` (total pending count) and `items` (sample with id, backend, key, reason, attempts, next_retry).
+
+#### `POST /admin/api/usage-flush`
+
+Forces an out-of-band flush of the in-memory usage counters to the database. Use after a manual quota adjustment to make the new value visible immediately instead of waiting up to `usage_flush.interval` seconds. Same effect as the scheduled flush; the operation is idempotent.
+
+```bash
+curl -X POST -H "X-Admin-Token: $TOKEN" http://localhost:9000/admin/api/usage-flush
+# {"status":"flushed"}
+```
+
+### Replication & over-replication
+
+#### `POST /admin/api/replicate`
+
+Triggers a single replication cycle synchronously. Useful after a backend recovery to fast-forward repair without waiting for the next scheduled tick.
+
+```bash
+curl -X POST -H "X-Admin-Token: $TOKEN" http://localhost:9000/admin/api/replicate
+# {"status":"ok","copies_created":42}
+# or {"status":"skipped","copies_created":0,"reason":"replication factor is 1"}
+```
+
+#### `GET /admin/api/over-replication` &middot; `POST /admin/api/over-replication[?batch_size=N]`
+
+The GET form reports how many object keys currently have more copies than the configured `replication.factor` requires. The POST form runs one cleanup pass that removes surplus replicas (preferring drained, circuit-broken, and most-utilised backends — see the `OverReplicationCleaner` section in the [Background Services diagram](../web/content/diagrams/background-services.md)).
+
+```bash
+curl -H "X-Admin-Token: $TOKEN" http://localhost:9000/admin/api/over-replication
+# {"factor":3,"pending":127}
+
+curl -X POST -H "X-Admin-Token: $TOKEN" "http://localhost:9000/admin/api/over-replication?batch_size=500"
+# {"status":"ok","copies_removed":127}
+```
+
+`batch_size` defaults to the configured value; the POST form clamps user input to 10000.
+
+### Drain & backend lifecycle
+
+#### `POST /admin/api/backends/{name}/drain`
+
+Begins draining `{name}`. Subsequent writes filter the backend out of eligibility (drain race re-check in `objects_write.go` covers the in-flight case), and the drain worker starts migrating existing objects to other healthy backends.
+
+```bash
+curl -X POST -H "X-Admin-Token: $TOKEN" http://localhost:9000/admin/api/backends/oci-old/drain
+# {"status":"drain started","backend":"oci-old"} (202)
+```
+
+Returns 400 if the backend is unknown or already draining.
+
+#### `GET /admin/api/backends/{name}/drain`
+
+Returns the drain's current state: total objects/bytes moved, total remaining, started_at, last_progress_at, and any per-batch errors. Poll this during a drain to track progress.
+
+#### `DELETE /admin/api/backends/{name}/drain`
+
+Cancels the active drain. In-flight migrations finish; new migrations stop. The backend's eligibility filter is re-enabled. Useful when a drain was triggered by accident or when the intended target's free space turns out to be insufficient.
+
+#### `DELETE /admin/api/backends/{name}[?purge=true&confirm=<token>]`
+
+**Non-purge** form (default): drops the backend's DB records (object_locations, quota, usage). The backend's actual S3 objects are left in place — reversible by re-adding the backend and running `s3-orchestrator admin sync`. Use this when retiring a backend whose data has already been migrated.
+
+```bash
+curl -X DELETE -H "X-Admin-Token: $TOKEN" http://localhost:9000/admin/api/backends/oci-old
+# {"status":"backend removed","backend":"oci-old"}
+```
+
+**Purge** form (two-phase, irreversible): also deletes every S3 object on the backend.
+
+```bash
+# Phase 1: preview
+curl -X DELETE -H "X-Admin-Token: $TOKEN" "http://localhost:9000/admin/api/backends/oci-old?purge=true"
+# {"status":"confirmation required","backend":"oci-old","object_count":4231,"total_bytes":92340876,"confirm_token":"<token>"}
+
+# Phase 2: confirm using the returned token within 5 minutes
+curl -X DELETE -H "X-Admin-Token: $TOKEN" "http://localhost:9000/admin/api/backends/oci-old?purge=true&confirm=<token>"
+# {"status":"backend purged","backend":"oci-old"}
+```
+
+The confirmation token is HMAC-bound to the backend name and expires after 5 minutes, so the preview cannot be replayed against a different backend or after a typo.
+
+### Encryption operations
+
+#### `POST /admin/api/rotate-encryption-key`
+
+Re-wraps every DEK still wrapped with the named old key using the current primary master key. Required after a key rotation (see [Rotating encryption keys](#rotating-encryption-keys) below).
+
+```bash
+curl -X POST -H "X-Admin-Token: $TOKEN" -H "Content-Type: application/json" \
+  -d '{"old_key_id":"config-0"}' \
+  http://localhost:9000/admin/api/rotate-encryption-key
+# {"status":"complete","rotated":1423,"failed":0,"total":1423}
+```
+
+`old_key_id` formats: inline keys → `config-0` (primary), `config-1`, ...; file-based → `file-0`; Vault Transit → the key name. Returns 400 if encryption is not enabled or the body is malformed.
+
+#### `POST /admin/api/encrypt-existing`
+
+Bulk-encrypts every object that does not yet have encryption metadata. The orchestrator downloads each object, encrypts it, re-uploads the ciphertext, and updates the DB record. Idempotent — re-running only processes objects that are still plaintext.
+
+```bash
+curl -X POST -H "X-Admin-Token: $TOKEN" http://localhost:9000/admin/api/encrypt-existing
+# {"status":"complete","encrypted":1423,"failed":0,"total":1423}
+```
+
+Counts against backend API quotas (one GET + one PUT per object).
+
+#### `POST /admin/api/decrypt-existing`
+
+Inverse of the above: downloads every encrypted object, decrypts it, re-uploads plaintext, and clears the encryption metadata. The orchestrator must still be configured with the key provider (the DEKs need to be unwrapped). Use only when permanently removing encryption from a deployment.
+
+```bash
+curl -X POST -H "X-Admin-Token: $TOKEN" http://localhost:9000/admin/api/decrypt-existing
+# {"status":"complete","decrypted":1423,"failed":0,"total":1423}
+```
+
+### Integrity
+
+#### `POST /admin/api/scrub[?batch_size=N]`
+
+Runs one integrity scrub pass: reads random objects from each backend, computes the SHA-256, and compares to the stored `content_hash`. On mismatch the bad copy is enqueued for cleanup with reason `integrity_scrub_failed`. The scrubber's scheduled runs are independent — this endpoint just triggers an immediate pass.
+
+```bash
+curl -X POST -H "X-Admin-Token: $TOKEN" "http://localhost:9000/admin/api/scrub?batch_size=200"
+# {"status":"ok","checked":200,"failed":0}
+# or {"status":"skipped","reason":"integrity verification not enabled"}
+```
+
+#### `POST /admin/api/backfill-checksums[?batch_size=N]`
+
+Computes and stores `content_hash` for every object that does not have one yet. Use after enabling `integrity.enabled: true` on an existing deployment so the scrubber has hashes to compare against. Paginates internally until done.
+
+```bash
+curl -X POST -H "X-Admin-Token: $TOKEN" "http://localhost:9000/admin/api/backfill-checksums?batch_size=500"
+# {"status":"ok","processed":12345}
+# or {"status":"skipped","reason":"integrity verification is not enabled"}
+```
+
+### Reconciliation
+
+#### `POST /admin/api/reconcile[?backend=<name>]`
+
+On-demand reconciler pass. See [On-demand reconciliation](#on-demand-reconciliation) above for the operator workflow and the bounded-memory sorted-merge details.
+
+### Cache management
+
+The object-data cache is optional (`cache.enabled: true`). All cache endpoints return 503 `{"status":"disabled","reason":"object data cache is not enabled"}` when the cache is not configured, so callers can distinguish "no cache" from "cache empty after flush".
+
+#### `GET /admin/api/cache`
+
+Current utilization: entry count, bytes used, configured max. Mirrors the `s3o_cache_*` gauges so operators without Prometheus access can still inspect cache state.
+
+```bash
+curl -H "X-Admin-Token: $TOKEN" http://localhost:9000/admin/api/cache
+# {"entries":2341,"size_bytes":83886080,"max_bytes":268435456}
+```
+
+#### `POST /admin/api/cache/flush`
+
+Drops every entry from the cache. Used by load-test tooling to characterise cache-cold GET performance. The response carries `entries_cleared` so the caller can confirm the cache was actually populated before the flush.
+
+```bash
+curl -X POST -H "X-Admin-Token: $TOKEN" http://localhost:9000/admin/api/cache/flush
+# {"status":"flushed","entries_cleared":2341}
+```
+
+#### `DELETE /admin/api/cache/keys/{key...}`
+
+Drops a single object from the cache. The `{key...}` wildcard pattern accepts keys with embedded slashes. Always returns 200 — invalidating an unknown key is a no-op, matching the cache's own contract.
+
+```bash
+curl -X DELETE -H "X-Admin-Token: $TOKEN" http://localhost:9000/admin/api/cache/keys/reports/2026-05.pdf
+```
+
+#### `DELETE /admin/api/cache/prefix?prefix=<prefix>`
+
+Drops every cached key under the given prefix. Useful after a bulk update for one tenant or directory. Returns 400 if `prefix` is empty — use `/admin/api/cache/flush` to clear the whole cache.
+
+```bash
+curl -X DELETE -H "X-Admin-Token: $TOKEN" "http://localhost:9000/admin/api/cache/prefix?prefix=reports/"
+```
 
 ## Common Operations
 

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -33,9 +33,18 @@ a `*_bench_test.go` file next to the code under test. See existing examples:
 | File | What it covers |
 |------|---------------|
 | `internal/transport/auth/auth_bench_test.go` | SigV4 verification, token auth, canonical request building |
-| `internal/proxy/location_cache_bench_test.go` | Cache get/set/delete, concurrent contention, eviction |
-| `internal/proxy/streaming_bench_test.go` | Raw io.Copy throughput, streamCopy end-to-end with mock backends |
+| `internal/transport/s3api/admission_bench_test.go` | Admission gate, split read/write pools |
+| `internal/transport/s3api/ratelimit_bench_test.go` | Per-credential rate limit checks |
 | `internal/transport/s3api/helpers_bench_test.go` | Path parsing, metadata extraction, XML encoding, error responses |
+| `internal/proxy/object/location_cache_bench_test.go` | Cache get/set/delete, concurrent contention, eviction |
+| `internal/proxy/object/copy_materialize_bench_test.go` | CopyObject materialize sink branches |
+| `internal/proxy/streaming_bench_test.go` | Raw io.Copy throughput, streamCopy end-to-end with mock backends |
+| `internal/counter/tracker_bench_test.go` | UsageTracker `WithinLimits` / `Record` under contention |
+| `internal/breaker/breaker_bench_test.go` | Circuit breaker call dispatch |
+| `internal/cache/memory_bench_test.go` | In-memory LRU |
+| `internal/encryption/nonce_bench_test.go` | Chunk nonce derivation |
+| `internal/observe/audit/audit_bench_test.go` | Audit log dispatch |
+| `internal/util/bufpool/bufpool_bench_test.go` | Pooled buffer get/put |
 
 ### 3. Run benchmarks again
 
@@ -79,7 +88,7 @@ Use judgement based on the operation:
 ## Running a subset
 
 ```bash
-go test -bench=BenchmarkLocationCache -benchmem -count=6 -run='^$' ./internal/proxy/ | tee bench.txt
+go test -bench=BenchmarkLocationCache -benchmem -count=6 -run='^$' ./internal/proxy/object/ | tee bench.txt
 ```
 
 ## Writing new benchmarks

--- a/docs/performance-tuning.md
+++ b/docs/performance-tuning.md
@@ -29,7 +29,12 @@ max_conns = max_concurrent_requests + (active_workers × 2) + 10
 - **Multi-instance deployment**: divide your PostgreSQL `max_connections` across instances. Each instance's `max_conns` should be `(max_connections - 20) / instance_count` (reserve 20 for superuser and monitoring connections).
 - `min_conns` keeps idle connections warm. Set it to roughly half of `max_conns` to avoid connection setup latency on traffic spikes.
 - `max_conn_lifetime` rotates connections to pick up DNS changes and distribute load across replicas. The 5-minute default works well in most environments.
-- Monitor `pgx_pool_acquired_conns` / `pgx_pool_total_conns` in Prometheus. If acquired consistently equals total, the pool is saturated.
+- The orchestrator does not export pool-level Prometheus metrics for the pgx
+  connection pool. To check for saturation, query PostgreSQL directly
+  (`SELECT count(*) FROM pg_stat_activity WHERE application_name LIKE 's3-orchestrator%'`)
+  or read the per-process `pg_stat_activity` row. Orchestrator-side request
+  saturation is best inferred from `s3o_inflight_requests` and
+  `s3o_admission_rejections_total`.
 
 ## Admission Control
 
@@ -275,10 +280,10 @@ cleanup_queue:
 
 ```yaml
 usage_flush:
-  interval: "30s"          # base flush interval
-  adaptive_enabled: true   # shorten interval near limits
-  adaptive_threshold: 0.8  # 80% of limit triggers fast flush
-  fast_interval: "5s"      # interval when near limits
+  interval: "30s"           # base flush interval
+  adaptive_enabled: false   # default false; set true to shorten interval near limits
+  adaptive_threshold: 0.8   # 80% of limit triggers fast flush (when adaptive_enabled: true)
+  fast_interval: "5s"       # interval when near limits (when adaptive_enabled: true)
 ```
 
 The orchestrator tracks API requests, egress, and ingress in memory and periodically flushes to the database. This is a tradeoff between accuracy and database load:

--- a/docs/security-hardening.md
+++ b/docs/security-hardening.md
@@ -127,7 +127,7 @@ Monitor encryption health with these Prometheus metrics:
 
 ### Nonce Safety
 
-Chunked encryption derives per-chunk nonces by XORing the chunk index into a random base nonce. AES-GCM security requires that the same (key, nonce) pair is never reused. This is guaranteed because each object gets a fresh random DEK and a fresh random base nonce — even re-uploads of identical content produce different ciphertext. See `internal/encryption/chunk.go` for the full safety invariant documentation.
+Chunked encryption derives per-chunk nonces by XORing the chunk index into a random base nonce. AES-GCM security requires that the same (key, nonce) pair is never reused. This is guaranteed because each object gets a fresh random DEK and a fresh random base nonce — even re-uploads of identical content produce different ciphertext. The `SAFETY INVARIANT` comment block at `internal/encryption/chunk.go:258-280` captures the three-clause reasoning (fresh DEK per object, fresh base nonce per call, sequential chunk indices) and notes when this derivation must be replaced (e.g., if the DEK-per-object invariant is ever relaxed for performance).
 
 ## SigV4 Path Handling
 

--- a/docs/version-migration.md
+++ b/docs/version-migration.md
@@ -28,7 +28,7 @@ Configuration changes are **not** applied automatically. When a new version adds
 
 ```bash
 s3-orchestrator version
-# s3-orchestrator v0.41.7 go1.26.0 linux/amd64
+# s3-orchestrator v0.57.1 go1.26.3 linux/amd64
 ```
 
 ## Compatibility Matrix
@@ -58,7 +58,124 @@ To roll back: restore the database backup and deploy the previous binary version
 
 ## Version History
 
-### v0.47.x (current)
+### v0.57.x (current)
+
+**Cleanup DELETE 404 treated as idempotent success ([#877](https://github.com/afreidah/s3-orchestrator/pull/877), v0.57.1)**
+
+A backend cleanup `DeleteObject` that returns HTTP 404 / `NoSuchKey` is now treated as idempotent success: the `cleanup_queue` row drops immediately instead of retrying nine more times and graduating to `cleanup_dlq`. The motivating incident: 63 phantom rows accumulated in `cleanup_dlq` against one MinIO backend over two days — all `StatusCode: 404`, none of them real un-cleanable orphans (the upstream PUTs had silently failed during a network outage, so the cleanup correctly identified objects to remove and got confused when the backend already agreed they didn't exist). The DLQ noise masked real un-cleanable orphans.
+
+The same 404 → drop logic was also added to `DeleteOrEnqueue` in the write coordinator, so a 404 never seeds the cleanup queue in the first place.
+
+New surfaces:
+
+- `s3o_cleanup_queue_processed_total{status="success_absent"}` — counter label for idempotent drops. Add this to dashboards alongside `success` / `retry` / `exhausted`.
+- `cleanup_queue.already_absent` audit event — emitted when the 404 path fires.
+
+`backend.IsNotFound` was promoted from a private worker helper to an exported function in `internal/backend/`. Existing call sites in `worker/replicator.go`, `worker/pending.go`, and `backend/circuitbreaker.go` were consolidated onto it.
+
+**Operator action items after upgrade:**
+
+- Update any dashboard panels that filter on `s3o_cleanup_queue_processed_total{status=~"success|retry|exhausted"}` to include `success_absent`.
+- No config change.
+
+**Close drain-race + fix `s3o_drain_active` semantics + bound purge loop ([#876](https://github.com/afreidah/s3-orchestrator/pull/876), v0.57.0)**
+
+Three related fixes around backend drain:
+
+1. **Drain race closed.** A drain that began while a backend `PutObject` was in flight could land bytes on the now-draining backend. The write path now re-checks `IsDraining(backend)` after the backend PUT succeeds, before the metadata commit. On a positive re-check the bytes are cleaned up via `RecoverFromRecordFailure` and the attempt fails over to the next eligible backend.
+2. **`s3o_drain_active` is now Inc/Dec instead of Set(1)/Set(0).** Concurrent drains across multiple backends now compose correctly — the gauge reports the count of in-flight drains, not just "is any drain running?".
+3. **`PurgeBackendObjects` bails on zero DB progress.** A pathological list-and-fail loop (e.g., the page-list works but every per-row `DeleteObjectLocation` fails) could spin indefinitely. The worker now exits the page when it finishes a list with zero rows actually deleted, preventing the infinite-list-and-fail spin.
+
+New surfaces:
+
+- `s3o_drain_race_aborted_total` (counter) — increments each time the post-PUT re-check fires.
+
+**Operator action items after upgrade:**
+
+- Dashboards / alerts that read `s3o_drain_active == 1` should switch to `s3o_drain_active > 0` to keep working when multiple drains overlap.
+- Add an alert on any non-zero rate of `s3o_drain_race_aborted_total`. A persistent rate suggests a longer-than-expected gap between `EligibleForWrite` and the backend PUT (e.g., very large objects against a fast-draining backend).
+
+### v0.55.x – v0.56.x
+
+**UsageTracker swapped to atomic.Pointer snapshots ([#874](https://github.com/afreidah/s3-orchestrator/pull/874), v0.56.0)**
+
+The internal `UsageTracker` (the per-backend rolling-window counter feeding `BackendsWithinLimits` and the eligibility filter) replaced its `sync.RWMutex` pair with `atomic.Pointer[T]` snapshots and copy-on-write writes. The hot read path no longer touches a mutex.
+
+No behavior change. Measured improvement on parallel `WithinLimits` benchmarks: 65.93 ns/op → 29.80 ns/op (~2.2× under contention). The change only matters at high request rates where `BackendsWithinLimits` is dispatched per request; below ~500 RPS it is in the noise.
+
+**Operator action items:** none.
+
+### v0.53.x – v0.54.x
+
+**Optimize PutObject buffering + integrity pipeline ([#869](https://github.com/afreidah/s3-orchestrator/pull/869), v0.54.0)**
+
+The `PutObject` body materialization layer (the buffer that lets the write path retry against a different backend on PUT failure) now spills to a tempfile above a configurable in-memory ceiling instead of always materializing to a `bytes.Buffer`. Combined with a heap-profile-friendly pipeline restructuring, container memory under sustained PUT load is significantly lower for workloads dominated by medium / large objects.
+
+**Operator action items after upgrade:**
+
+- Container memory limits sized off pre-v0.54 baselines can be tightened; equivalently, the previous limits absorb more concurrent in-flight PUTs.
+- Tempfiles are written under the orchestrator's `TMPDIR` (defaults to `/tmp`). Operators running with a tmpfs `/tmp` should size it to accommodate `max_concurrent_writes × p99_object_size`, or set `TMPDIR` to a disk-backed location.
+
+**Same-backend server-side copy fast path ([#868](https://github.com/afreidah/s3-orchestrator/pull/868), v0.53.0)**
+
+`CopyObject` requests whose source and destination resolve to the same backend now dispatch through the backend's native `CopyObject` API (S3 `UploadPartCopy` / equivalent) instead of materializing through the orchestrator. This avoids one full GET + one full PUT per copy when the routing target matches the source backend.
+
+New surfaces:
+
+- Span attribute `s3o.native_copy=true` on the `CopyObject` span when the fast path is taken. Useful for trace filtering and for confirming the fast path actually fires in production.
+- Per-backend accounting: the fast path records 1 API call against the backend and no egress/ingress (the bytes never traverse the orchestrator). Dashboards that derived "bytes copied" from `egress + ingress` will see a discontinuity if their workload is copy-heavy on the same backend.
+
+**Operator action items after upgrade:**
+
+- If you compute "data transferred" from `s3o_usage_egress_bytes` + `s3o_usage_ingress_bytes`, native-copy traffic is now invisible to that metric (which is correct — no bytes left the backend). Add a panel querying for spans with `s3o.native_copy=true` if you need a copy-volume signal.
+
+### v0.51.x – v0.52.x
+
+**Per-operation completion observability centralized ([#866](https://github.com/afreidah/s3-orchestrator/pull/866), v0.52.0)**
+
+The audit / metric / span completion logic for `PutObject`, `GetObject`, `DeleteObject`, `HeadObject`, and the multipart operations was consolidated into a single `observe.Complete*` helper per operation. The behavior is unchanged for the existing audit events, but `storage.UploadPart` is now emitted on every successful part upload (previously only `CompleteMultipartUpload` emitted an event). This makes per-part backend distribution visible in audit logs.
+
+**Operator action items after upgrade:**
+
+- Audit log sinks that filter on `event=storage.UploadPart` will start seeing one entry per part. For a multipart of N parts, expect roughly N new entries per upload.
+
+**Cancel losing degraded-read probes ([#867](https://github.com/afreidah/s3-orchestrator/pull/867), v0.52.1)**
+
+When the read path is in degraded mode (one source unhealthy) it fires probe reads against multiple backends and serves the first one back. The losing probes were previously left to run to completion, wasting backend API calls and egress against quotas. They are now cancelled the moment a winner is declared. The visible effect is a drop in `s3o_usage_api_calls{backend=...}` during degraded operation, with no change to correctness or latency.
+
+**Operator action items:** none.
+
+### v0.49.x – v0.50.x
+
+**Consumer-declared interfaces for proxy subpackages ([#847](https://github.com/afreidah/s3-orchestrator/pull/847), v0.49.0)**
+
+The proxy package was split into subpackages (`object`, `multipart`, `readpath`, `writepath`, `accounting`, etc.), each declaring its own narrow consumer interface against `*infra.Core` and the metadata store rather than importing the root `proxy` package. Internally-significant refactor.
+
+Operator-visible: structured-log entries that used `component=backend_manager` now use `component=object`, `component=multipart`, or `component=writepath` depending on the subsystem doing the logging.
+
+**Operator action items after upgrade:**
+
+- Log-search saved queries that filter on `component=backend_manager` should add the new component names (`object`, `multipart`, `writepath`, `readpath`).
+- Grafana log panels keyed on `component` will gain new series; old series will go quiet but not break.
+
+### v0.48.x
+
+Internal refactor only (proxy package decomposed into focused subpackages, [#845](https://github.com/afreidah/s3-orchestrator/pull/845)). No operator-visible behavior change. No action required.
+
+### v0.47.x
+
+**Surface orphan-enqueue failures during DB outages ([#824](https://github.com/afreidah/s3-orchestrator/pull/824), v0.47.5)**
+
+When the write path enqueues a cleanup row after a partial write failure and the enqueue itself fails (e.g., the DB is unreachable), the orphan bytes were previously silent — the backend held data the orchestrator could not see. The failure path now emits a metric and an audit event so operators can pivot to the exact backend / key / size and reconcile manually once DB connectivity returns.
+
+New surfaces:
+
+- `s3o_cleanup_enqueue_failures_total{backend, reason, stage}` counter. `stage="enqueue"` means the cleanup_queue row itself did not persist (worst case — the cleanup worker will never see this orphan). `stage="orphan_bytes"` means the row persisted but the `orphan_bytes` counter did not increment (quota accounting drifts but cleanup still runs).
+- `storage.OrphanEnqueueFailed` audit event carrying backend, key, size, stage, error.
+
+**Operator action items after upgrade:**
+
+- Alert on any non-zero rate of `s3o_cleanup_enqueue_failures_total{stage="enqueue"}` and run `POST /admin/api/reconcile` once DB connectivity returns to recover untracked orphans. See the admin guide cleanup runbook for the full procedure.
 
 **Background worker health surfaced through admin API and Prometheus (v0.47.0)**
 

--- a/grafana/s3-orchestrator.json
+++ b/grafana/s3-orchestrator.json
@@ -1167,7 +1167,7 @@
       "targets": [
         {
           "expr": "sum by (name, from, to) (increase(s3o_circuit_breaker_transitions_total[5m]))",
-          "legendFormat": "{{name}}: {{from}} \u2192 {{to}}"
+          "legendFormat": "{{name}}: {{from}} → {{to}}"
         }
       ],
       "options": {
@@ -3808,6 +3808,463 @@
           }
         }
       }
+    },
+    {
+      "type": "row",
+      "id": 86,
+      "title": "Worker Health",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 193,
+        "w": 24,
+        "h": 1
+      }
+    },
+    {
+      "type": "timeseries",
+      "id": 87,
+      "title": "Worker tick rate by service & result",
+      "gridPos": {
+        "x": 0,
+        "y": 194,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum by (service, result) (rate(s3o_worker_ticks_total[5m]))",
+          "legendFormat": "{{service}} {{result}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 88,
+      "title": "Consecutive failures per worker (gauge)",
+      "gridPos": {
+        "x": 12,
+        "y": 194,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "s3o_worker_consecutive_failures",
+          "legendFormat": "{{service}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 89,
+      "title": "Seconds since last successful tick",
+      "gridPos": {
+        "x": 0,
+        "y": 202,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "time() - s3o_worker_last_success_timestamp_seconds",
+          "legendFormat": "{{service}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 90,
+      "title": "Worker admission rejections",
+      "gridPos": {
+        "x": 12,
+        "y": 202,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum by (worker) (rate(s3o_worker_admission_rejections_total[5m]))",
+          "legendFormat": "{{worker}}"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "id": 91,
+      "title": "Event Notifications",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 210,
+        "w": 24,
+        "h": 1
+      }
+    },
+    {
+      "type": "stat",
+      "id": 92,
+      "title": "Notification queue depth",
+      "gridPos": {
+        "x": 0,
+        "y": 211,
+        "w": 6,
+        "h": 4
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "s3o_notification_queue_depth"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 93,
+      "title": "Notifications sent / failed / dropped",
+      "gridPos": {
+        "x": 6,
+        "y": 211,
+        "w": 18,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(s3o_notification_sent_total[5m]))",
+          "legendFormat": "sent"
+        },
+        {
+          "expr": "sum(rate(s3o_notification_failed_total[5m]))",
+          "legendFormat": "failed"
+        },
+        {
+          "expr": "sum(rate(s3o_notification_dropped_total[5m]))",
+          "legendFormat": "dropped"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 94,
+      "title": "Notification delivery duration (p95)",
+      "gridPos": {
+        "x": 0,
+        "y": 219,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(s3o_notification_duration_seconds_bucket[5m])))",
+          "legendFormat": "p95"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 95,
+      "title": "Notification store errors",
+      "gridPos": {
+        "x": 12,
+        "y": 219,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(s3o_notification_store_errors_total[5m]))",
+          "legendFormat": "store errors"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "id": 96,
+      "title": "Cleanup DLQ & Enqueue Failures",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 227,
+        "w": 24,
+        "h": 1
+      }
+    },
+    {
+      "type": "stat",
+      "id": 97,
+      "title": "Cleanup DLQ depth",
+      "gridPos": {
+        "x": 0,
+        "y": 228,
+        "w": 6,
+        "h": 4
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "s3o_cleanup_dlq_depth"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 98,
+      "title": "Rows graduated to DLQ by backend",
+      "gridPos": {
+        "x": 6,
+        "y": 228,
+        "w": 18,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum by (backend) (rate(s3o_cleanup_dlq_enqueued_total[15m]))",
+          "legendFormat": "{{backend}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 99,
+      "title": "Cleanup enqueue failures (untracked-orphan risk)",
+      "gridPos": {
+        "x": 0,
+        "y": 236,
+        "w": 24,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum by (backend, stage) (rate(s3o_cleanup_enqueue_failures_total[5m]))",
+          "legendFormat": "{{backend}} {{stage}}"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "id": 100,
+      "title": "Coverage Backfill",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 244,
+        "w": 24,
+        "h": 1
+      }
+    },
+    {
+      "type": "timeseries",
+      "id": 101,
+      "title": "Drain race aborts (#653)",
+      "gridPos": {
+        "x": 0,
+        "y": 245,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(s3o_drain_race_aborted_total[5m]))",
+          "legendFormat": "aborted"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 102,
+      "title": "List page cap hits",
+      "gridPos": {
+        "x": 12,
+        "y": 245,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(s3o_list_pages_capped_total[5m]))",
+          "legendFormat": "capped"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 103,
+      "title": "Circuit breaker internal errors",
+      "gridPos": {
+        "x": 0,
+        "y": 253,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum by (name) (rate(s3o_circuit_breaker_internal_errors_total[5m]))",
+          "legendFormat": "{{name}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 104,
+      "title": "Admission client cancellations",
+      "gridPos": {
+        "x": 12,
+        "y": 253,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(s3o_admission_client_canceled_total[5m]))",
+          "legendFormat": "canceled"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 105,
+      "title": "Decrypt-existing admin op",
+      "gridPos": {
+        "x": 0,
+        "y": 261,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum by (status) (rate(s3o_decrypt_existing_objects_total[5m]))",
+          "legendFormat": "{{status}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 106,
+      "title": "Cache admin invalidations & flushes",
+      "gridPos": {
+        "x": 12,
+        "y": 261,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(s3o_cache_admin_invalidations_total[5m]))",
+          "legendFormat": "invalidations"
+        },
+        {
+          "expr": "sum(rate(s3o_cache_flush_total[5m]))",
+          "legendFormat": "flushes"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 107,
+      "title": "Over-replication cleaner runs",
+      "gridPos": {
+        "x": 0,
+        "y": 269,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum by (status) (rate(s3o_over_replication_runs_total[5m]))",
+          "legendFormat": "{{status}}"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "id": 108,
+      "title": "Objects tracked (total)",
+      "gridPos": {
+        "x": 12,
+        "y": 269,
+        "w": 12,
+        "h": 4
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum(s3o_objects_count)",
+          "legendFormat": "objects"
+        }
+      ]
     }
   ]
 }

--- a/web/content/diagrams/architecture.md
+++ b/web/content/diagrams/architecture.md
@@ -97,6 +97,8 @@ High-level architecture of the S3 Orchestrator showing the request path, storage
     '    MPCLEAN[Multipart<br>Cleanup]:::background --> MPMGR',
     '    OVERREP[Over-Replication<br>Cleaner]:::background --> SELECT',
     '    OVERREP --> PG',
+    '    PENDREAP[Pending<br>Reaper]:::background --> PG',
+    '    PENDREAP --> CB1',
     '',
     '    HTTP --> PROM[Prometheus<br>Metrics]:::observability',
     '    HTTP --> TEMPO[OpenTelemetry<br>Tracing]:::observability',
@@ -272,6 +274,11 @@ High-level architecture of the S3 Orchestrator showing the request path, storage
       title: 'Over-Replication Cleaner',
       badge: 'background', badgeText: 'background worker',
       body: '<p>Finds objects with more copies than the configured replication factor and deletes excess replicas. Runs every 6 hours under advisory lock.</p><p>Preserves geographically diverse copies when possible. Frees up quota on backends holding unnecessary duplicates.</p><p><a href="../background-services/">Background services coordination diagram &rarr;</a></p>'
+    },
+    PENDREAP: {
+      title: 'Pending Reaper',
+      badge: 'background', badgeText: 'background worker',
+      body: '<p>Resolves unresolved <code>pending_objects</code> rows from the write-path PUT-before-COMMIT pattern. If the orchestrator died between the backend PUT and the metadata commit, this worker is what makes the orphan recoverable: it HEADs the backend and either promotes the intent (HEAD 200) or drops it (HEAD 404).</p><p>Runs every <code>write_path.pending_pattern.reaper_tick</code> (default 1 min), processing intents older than <code>min_age</code> (default 5 min) in batches of <code>batch_size</code> (default 50) with concurrency 4. Per-row claim via <code>SELECT ... FOR UPDATE SKIP LOCKED</code> &mdash; no advisory lock.</p><p><a href="../background-services/">Background services coordination diagram &rarr;</a> &middot; <a href="../write-path/">Write path diagram &rarr;</a></p>'
     },
     PROM: {
       title: 'Prometheus Metrics',

--- a/web/content/diagrams/background-services.md
+++ b/web/content/diagrams/background-services.md
@@ -51,6 +51,7 @@ Coordination of periodic background workers that maintain storage health, enforc
     '    SCHED --> MPCLEAN[Multipart<br>Cleanup]:::process',
     '    SCHED --> FLUSH[Usage<br>Flusher]:::filter',
     '    SCHED --> CQWORKER[Cleanup Queue<br>Worker]:::cleanup',
+    '    SCHED --> PENDREAP[Pending<br>Reaper]:::process',
     '    SCHED --> RECONCILE[Orphan<br>Reconciler]:::process',
     '    SCHED --> SCRUBBER[Integrity<br>Scrubber]:::process',
     '    SCHED --> CBWATCH[CB<br>Watchdog]:::filter',
@@ -69,6 +70,8 @@ Coordination of periodic background workers that maintain storage health, enforc
     '    REBAL -->|on failure| CQ',
     '    OVERREP -->|on failure| CQ',
     '    CQWORKER -->|fetch items| CQ',
+    '    PENDREAP -->|HEAD probe| S3',
+    '    PENDREAP -->|read + resolve| PG',
     '',
     '    FLUSH -->|persist| PG[(PostgreSQL)]:::storage',
     '',
@@ -132,6 +135,11 @@ Coordination of periodic background workers that maintain storage health, enforc
       title: 'Cleanup Queue Worker',
       badge: 'cleanup', badgeText: 'every 1 min',
       body: '<p><code>CleanupWorker.ProcessCleanupQueue()</code> retries failed object deletions from the <code>cleanup_queue</code> table.</p><p><b>Interval</b>: 1 minute.<br><b>Advisory lock</b>: <code>LockCleanupQueue = 1003</code>.<br><b>Batch size</b>: 50 items per tick.<br><b>Concurrency</b>: configurable (default 10).<br><b>Claim grace period</b>: configurable via <code>cleanup_queue.claim_grace_period</code> (default 5m).</p><p><b>Per-row claim pattern</b>: each tick calls <code>ClaimPendingCleanups</code>, which uses <code>UPDATE ... WHERE id IN (SELECT ... FOR UPDATE SKIP LOCKED)</code> to atomically reserve a batch of rows and stamp them with the calling instance\'s identifier (<code>claimed_at</code>, <code>claimed_by</code>). Two ticks running concurrently across instances always return disjoint row sets, so connection death and rolling-deploy overlap cannot let two workers process the same row. A claim older than the grace period is reclaimable so a worker that died mid-process does not leave the row stuck; reclaims emit <code>s3o_cleanup_queue_stale_claims_recovered_total</code> and a <code>cleanup_queue.claim_recovered</code> audit event.</p><p><b>Backoff</b>: exponential <code>min(1m * 2^attempts, 24h)</code>. Scheduling a retry clears the row\'s claim so it is immediately re-eligible for the next tick.<br><b>Max attempts</b>: 10. On the tenth consecutive failure the row is graduated to <code>cleanup_dlq</code> via <code>core.MoveCleanupToDLQ</code> so it surfaces for operator action; <code>orphan_bytes</code> is intentionally NOT decremented because the backend object is still on disk.</p><p>Items are fed from all failure sites: <code>recordObjectOrCleanup</code>, <code>DeleteObject</code>, <code>UploadPart</code>, <code>CompleteMultipartUpload</code>, <code>AbortMultipartUpload</code>, rebalancer (3 sites), replicator. On success, <code>CompleteCleanupItem</code> deletes the row and decrements <code>orphan_bytes</code> for the backing backend in a single atomic CTE; a worker crash between the two operations cannot leave the counter inconsistent and a re-claim of an already-deleted row is a no-op.</p><p class="ac-metric">Metrics: s3o_cleanup_queue_enqueued_total{reason}, s3o_cleanup_queue_processed_total{status=success|retry|exhausted}, s3o_cleanup_queue_depth, s3o_cleanup_queue_stale_claims_recovered_total{backend}, s3o_cleanup_dlq_enqueued_total{backend}, s3o_cleanup_dlq_depth</p>'
+    },
+    PENDREAP: {
+      title: 'Pending Reaper',
+      badge: 'process', badgeText: 'every 1 min',
+      body: '<p><code>PendingReaper.Reap()</code> resolves unresolved <code>pending_objects</code> rows from the write-path PUT-before-COMMIT pattern. If the orchestrator died between the backend PUT and the metadata commit, this worker is what makes the orphan recoverable.</p><p><b>Interval</b>: configurable via <code>write_path.pending_pattern.reaper_tick</code> (default 1 minute).<br><b>Min age</b>: configurable via <code>write_path.pending_pattern.min_age</code> (default 5 minutes) &mdash; only intents older than this are eligible, so the reaper never races a still-in-flight PUT.<br><b>Batch size</b>: configurable via <code>write_path.pending_pattern.batch_size</code> (default 50).<br><b>Concurrency</b>: 4 (hard-coded in <code>NewPendingReaper</code>).<br><b>Advisory lock</b>: none &mdash; rows are claimed individually with <code>SELECT ... FOR UPDATE SKIP LOCKED</code>.</p><p>For each stale intent: HEAD the backend at the target key. HEAD 200 &rarr; promote (commit the intent as a real <code>object_locations</code> row). HEAD 404 &rarr; drop (the backend never received the bytes, no orphan exists).</p><p class="ac-metric">Metrics: s3o_pending_intents_enqueued_total, s3o_pending_intents_resolved_total{status=committed|promoted|dropped|ambiguous|already_resolved}, s3o_pending_intents_depth</p>'
     },
     SCRUBBER: {
       title: 'Integrity Scrubber',
@@ -259,4 +267,5 @@ Coordination of periodic background workers that maintain storage health, enforc
 | Multipart Cleanup | 1 hr | 1004 | `CleanupStaleMultipartUploads()` |
 | Usage Flusher | 30s (adaptive) | 1007 (Redis only) | `FlushUsage()` |
 | Cleanup Queue Worker | 1 min | 1003 | `ProcessCleanupQueue()` |
+| Pending Reaper | 1 min (configurable) | none (per-row claim) | `PendingReaper.Reap()` |
 

--- a/web/content/diagrams/database-schema.md
+++ b/web/content/diagrams/database-schema.md
@@ -125,6 +125,19 @@ Entity-relationship diagram of the PostgreSQL metadata store. **Hover over any t
     '        TEXT last_error',
     '    }',
     '',
+    '    pending_objects {',
+    '        TEXT intent_id PK',
+    '        TEXT object_key',
+    '        TEXT backend_name FK',
+    '        BIGINT size_bytes',
+    '        BOOLEAN encrypted',
+    '        BYTEA encryption_key',
+    '        TEXT key_id',
+    '        BIGINT plaintext_size',
+    '        TEXT content_hash',
+    '        TIMESTAMPTZ created_at',
+    '    }',
+    '',
     '    notification_outbox {',
     '        BIGSERIAL id PK',
     '        TEXT event_type',
@@ -141,6 +154,7 @@ Entity-relationship diagram of the PostgreSQL metadata store. **Hover over any t
     '    backend_quotas ||--o{ backend_usage : "monthly usage"',
     '    backend_quotas ||--o{ cleanup_queue : "pending deletes"',
     '    backend_quotas ||--o{ cleanup_dlq : "exhausted orphans"',
+    '    backend_quotas ||--o{ pending_objects : "in-flight intents"',
     '    cleanup_queue ||--o| cleanup_dlq : "graduates on retry exhaustion"',
     '    multipart_uploads ||--o{ multipart_parts : "upload parts"'
   ].join('\n');
@@ -278,6 +292,25 @@ Entity-relationship diagram of the PostgreSQL metadata store. **Hover over any t
         '<p class="ac-metric">Key queries: InsertCleanupDLQ, CountCleanupDLQ</p>' +
         '<p class="ac-metric">Metrics: cleanup_dlq_depth (gauge), cleanup_dlq_enqueued_total{backend} (counter)</p>'
     },
+    pending_objects: {
+      title: 'pending_objects',
+      badge: 'cleanup', badgeText: 'in-flight intents',
+      body: '<p>In-flight PUT intents for the write-path PUT-before-COMMIT pattern. A row is inserted by <code>InsertPendingIntent</code> immediately before the backend PUT and deleted by <code>RecordObjectAndPromoteIntent</code> on a successful metadata commit. If the orchestrator dies between the backend PUT and the commit, the row survives and the <code>PendingReaper</code> worker resolves it on the next tick by HEADing the backend.</p>' +
+        '<table class="ac-cols"><tr><th>Column</th><th>Type</th><th>Notes</th></tr>' +
+        '<tr><td class="pk">intent_id</td><td>TEXT</td><td>PRIMARY KEY (UUID v4 minted by the coordinator)</td></tr>' +
+        '<tr><td>object_key</td><td>TEXT</td><td>S3 key the PUT targets</td></tr>' +
+        '<tr><td class="fk">backend_name</td><td>TEXT</td><td>FK &rarr; backend_quotas; target of the in-flight PUT</td></tr>' +
+        '<tr><td>size_bytes</td><td>BIGINT</td><td>Ciphertext size (or plaintext if encryption disabled)</td></tr>' +
+        '<tr><td>encrypted</td><td>BOOLEAN</td><td>true when an EncryptionMeta is captured below</td></tr>' +
+        '<tr><td>encryption_key</td><td>BYTEA</td><td>Wrapped DEK (baseNonce || wrappedDEK) when encrypted</td></tr>' +
+        '<tr><td>key_id</td><td>TEXT</td><td>Master key identifier for unwrap</td></tr>' +
+        '<tr><td>plaintext_size</td><td>BIGINT</td><td>Logical object size (pre-encryption)</td></tr>' +
+        '<tr><td>content_hash</td><td>TEXT</td><td>SHA-256 of the plaintext (when integrity is enabled)</td></tr>' +
+        '<tr><td>created_at</td><td>TIMESTAMPTZ</td><td>Intent creation time; reaper only considers rows older than <code>write_path.pending_pattern.min_age</code> (default 5m)</td></tr></table>' +
+        '<p class="ac-idx"><b>Indexes:</b> PK on intent_id &bull; idx_pending_objects_created_at (created_at) for the reaper\'s age-cursored scan</p>' +
+        '<p>Used by: <code>writepath.Coordinator.InsertPendingIntent</code> (inserts on PUT entry) &bull; <code>RecordObjectAndPromoteIntent</code> (delete on successful commit) &bull; <code>RecoverFromRecordFailure</code> (delete on drain race / commit failure) &bull; <a href="../background-services/">PendingReaper</a> (HEAD-probes the backend and promotes / drops stale intents). The reaper claims rows individually with <code>SELECT ... FOR UPDATE SKIP LOCKED</code>; no advisory lock is required because two reapers ticking concurrently always pick disjoint sets.</p>' +
+        '<p class="ac-metric">Metrics: s3o_pending_intents_enqueued_total, s3o_pending_intents_resolved_total{status=committed|promoted|dropped|ambiguous|already_resolved}, s3o_pending_intents_depth &bull; Audit events: pending_reaper.promoted, pending_reaper.dropped, pending_reaper.superseded</p>'
+    },
     notification_outbox: {
       title: 'notification_outbox',
       badge: 'usage', badgeText: 'notifications',
@@ -342,7 +375,7 @@ Entity-relationship diagram of the PostgreSQL metadata store. **Hover over any t
       // Mermaid ER diagram entity IDs follow the pattern: entity-TABLE_NAME-N
       // or just the table name directly. Try to extract the table name.
       var tableName = null;
-      var tableNames = ['backend_quotas', 'object_locations', 'multipart_uploads', 'multipart_parts', 'backend_usage', 'cleanup_queue', 'cleanup_dlq', 'notification_outbox'];
+      var tableNames = ['backend_quotas', 'object_locations', 'multipart_uploads', 'multipart_parts', 'backend_usage', 'cleanup_queue', 'cleanup_dlq', 'pending_objects', 'notification_outbox'];
       for (var i = 0; i < tableNames.length; i++) {
         if (gId.indexOf(tableNames[i]) !== -1) {
           tableName = tableNames[i];
@@ -386,6 +419,7 @@ Entity-relationship diagram of the PostgreSQL metadata store. **Hover over any t
 | **backend_usage** | Monthly API/bandwidth counters per backend | `(backend_name, period)` |
 | **cleanup_queue** | Retry queue for failed orphan deletions | `id` (auto-increment) |
 | **cleanup_dlq** | Dead-letter for cleanup_queue rows that exhausted retries | `id` (auto-increment) |
+| **pending_objects** | In-flight PUT intents (PUT-before-COMMIT write-path crash recovery) | `intent_id` (UUID) |
 | **notification_outbox** | Durable webhook event delivery queue | `id` (auto-increment) |
 
 ### Schema Migrations

--- a/web/content/diagrams/write-path.md
+++ b/web/content/diagrams/write-path.md
@@ -70,14 +70,18 @@ Detailed flow of a PutObject request through backend selection, encryption, fail
     '',
     '    ENC{Encryption<br>Enabled?}:::decision',
     '    ENC -->|yes| ENCRYPT[Generate DEK<br>Wrap + Encrypt]:::process',
-    '    ENC -->|no| UPLOAD',
-    '    ENCRYPT --> UPLOAD',
+    '    ENC -->|no| INTENT',
+    '    ENCRYPT --> INTENT',
     '',
+    '    INTENT[InsertPendingIntent<br>pending_objects row]:::storage --> UPLOAD',
     '    UPLOAD[Upload to<br>Backend]:::process --> CB{Circuit<br>Breaker}:::decision',
     '    CB -->|open| FAIL',
     '    CB -->|closed/probe| S3[S3 Backend<br>PutObject]:::storage',
     '    S3 -->|error| FAIL{Upload<br>Failed?}:::decision',
-    '    S3 -->|success| RECORD',
+    '    S3 -->|success| DRAINRACE{IsDraining<br>re-check?}:::decision',
+    '    DRAINRACE -->|drain started| DRAINABORT[Drain Race Abort<br>cleanup + failover]:::cleanup',
+    '    DRAINRACE -->|backend healthy| RECORD',
+    '    DRAINABORT --> RETRY',
     '',
     '    FAIL -->|backends remain| RETRY[Remove Backend<br>from Eligible]:::process',
     '    RETRY --> SELECT',
@@ -223,9 +227,24 @@ Detailed flow of a PutObject request through backend selection, encryption, fail
       body: '<p>All eligible backends have been tried and failed. Returns the last error encountered, which propagates to the HTTP handler as a 502 Bad Gateway.</p><p>The span is marked with error status and the error is recorded for tracing.</p>'
     },
     RECORD: {
-      title: 'Record Object in PostgreSQL',
+      title: 'RecordObjectAndPromoteIntent (atomic commit)',
       badge: 'storage', badgeText: 'DB transaction',
-      body: '<p>Atomic database transaction (<code>RecordObject</code>):</p><p>1. <code>LockObjectKeyForWrite</code> &mdash; advisory lock for concurrent write safety<br>2. <code>GetExistingCopiesForUpdate</code> &mdash; SELECT FOR UPDATE on current copies<br>3. <code>DeleteObjectCopies</code> &mdash; remove all existing copies<br>4. <code>DecrementQuota</code> for each deleted copy<br>5. <code>InsertObjectLocation</code> &mdash; new record with encryption metadata<br>6. <code>IncrementQuota</code> for the new backend</p><p>Returns list of <b>displaced copies</b> on other backends that need cleanup.</p><p>If this transaction fails, the orphaned upload is deleted from the backend (or enqueued to cleanup queue if that also fails).</p>'
+      body: '<p>Atomic database transaction (<code>RecordObjectAndPromoteIntent</code>) that flips the pending intent to a committed object_locations row:</p><p>1. <code>LockObjectKeyForWrite</code> &mdash; advisory lock for concurrent write safety<br>2. <code>GetExistingCopiesForUpdate</code> &mdash; SELECT FOR UPDATE on current copies<br>3. <code>DeleteObjectCopies</code> &mdash; remove all existing copies<br>4. <code>DecrementQuota</code> for each deleted copy<br>5. <code>InsertObjectLocation</code> &mdash; new record with encryption metadata<br>6. <code>IncrementQuota</code> for the new backend<br>7. <code>DeletePendingIntent</code> &mdash; clear the intent row</p><p>Returns list of <b>displaced copies</b> on other backends that need cleanup.</p><p>If this transaction fails, <code>RecoverFromRecordFailure</code> deletes the orphaned backend bytes and the intent stays for the <code>PendingReaper</code> to resolve.</p>'
+    },
+    INTENT: {
+      title: 'InsertPendingIntent',
+      badge: 'storage', badgeText: 'DB transaction',
+      body: '<p><code>InsertPendingIntent</code> writes a row into the <code>pending_objects</code> table <b>before</b> the backend PUT. The row captures everything needed to recover from a crash mid-write: object key, target backend, size, and (if encryption is on) the wrapped DEK / keyID / content hash.</p><p>If the orchestrator dies between the backend PUT and the metadata commit, the <code>PendingReaper</code> worker later finds this intent, HEADs the backend, and either promotes the intent (HEAD 200) or drops it (HEAD 404).</p><p class="ac-metric">Metric: s3o_pending_intents_enqueued_total</p>'
+    },
+    DRAINRACE: {
+      title: 'IsDraining Re-Check (drain race)',
+      badge: 'decision', badgeText: 'drain race guard',
+      body: '<p>Post-PUT guard added by <a href="https://github.com/afreidah/s3-orchestrator/issues/653">#653</a>. The upstream <code>EligibleForWrite</code> filter is racy with <code>StartDrain</code>: a drain can begin <em>while</em> the backend PUT is in flight, landing bytes on a backend that is then drained.</p><p>This re-check fires after the PUT succeeds but before the metadata commit. If <code>IsDraining(backend)</code> is now true, the bytes are cleaned up via <code>RecoverFromRecordFailure</code> and the attempt fails over to the next eligible backend.</p><p class="ac-metric">Metric: s3o_drain_race_aborted_total</p>'
+    },
+    DRAINABORT: {
+      title: 'Drain Race Abort + Failover',
+      badge: 'cleanup', badgeText: 'cleanup + failover',
+      body: '<p>The bytes landed on a backend that started draining mid-write. <code>RecoverFromRecordFailure</code> issues a best-effort DELETE for the orphan bytes (enqueueing a cleanup row if the immediate DELETE also fails), the pending intent is dropped, and the attempt is re-driven against the next eligible backend.</p>'
     },
     DISPLACED: {
       title: 'Displaced Copies?',
@@ -338,6 +357,14 @@ Detailed flow of a PutObject request through backend selection, encryption, fail
   }
 })();
 </script>
+
+## Pending-Intent Pattern
+
+The `InsertPendingIntent` → `RecordObjectAndPromoteIntent` two-phase pattern exists so a crash between the backend PUT and the metadata commit cannot leak orphan bytes. The intent row captures everything the recovery path needs (key, backend, size, encryption metadata) so on restart the `PendingReaper` worker can HEAD the backend and decide *commit* (HEAD 200 → promote the intent) or *cleanup* (HEAD 404 → drop the intent, enqueue cleanup).
+
+The post-PUT `IsDraining` re-check guards a separate race: a drain can begin while the backend PUT is in flight. Without the re-check, the bytes would land on the draining backend and the drain worker would have to move them off again. With it, the orchestrator aborts the attempt and fails over to the next eligible backend, incrementing `s3o_drain_race_aborted_total`.
+
+See [`internal/worker/pending.go`](https://github.com/afreidah/s3-orchestrator/blob/main/internal/worker/pending.go) for the reaper implementation and [`internal/proxy/writepath/coordinator.go`](https://github.com/afreidah/s3-orchestrator/blob/main/internal/proxy/writepath/coordinator.go) for the coordinator-side helpers.
 
 ## Legend
 

--- a/web/content/guides/encrypting-existing-data.md
+++ b/web/content/guides/encrypting-existing-data.md
@@ -8,7 +8,7 @@ This guide walks through enabling server-side encryption on an S3 Orchestrator i
 
 ## Overview
 
-When you enable encryption, only **new** objects are encrypted automatically. Existing objects remain unencrypted until you explicitly encrypt them using the `encrypt-existing` admin command. This is a one-time operation that processes all unencrypted objects in batches.
+When you enable encryption, only **new** objects are encrypted automatically. Existing objects remain unencrypted until you explicitly encrypt them via the `/admin/api/encrypt-existing` endpoint. This is a one-time operation that processes all unencrypted objects in batches.
 
 ## Prerequisites
 
@@ -60,10 +60,12 @@ After restarting, all new objects will be encrypted automatically. Existing obje
 
 ## Step 4: Encrypt Existing Objects
 
-Run the admin command to encrypt all existing unencrypted objects:
+Encrypt all existing unencrypted objects by hitting the admin API. The
+orchestrator does not ship a CLI subcommand for this — use the HTTP endpoint:
 
 ```bash
-s3-orchestrator admin encrypt-existing
+curl -X POST http://orchestrator-host:9000/admin/api/encrypt-existing \
+  -H "Authorization: Bearer ${ADMIN_TOKEN}"
 ```
 
 This processes objects in batches of 100: each object is downloaded from its backend, encrypted, re-uploaded (overwriting the plaintext), and its database record is updated. The response shows progress:
@@ -85,7 +87,7 @@ Monitor the `s3o_encrypt_existing_objects_total` metric:
 | `success` | Objects successfully encrypted |
 | `error` | Objects that failed encryption |
 
-If any objects failed, check the logs for details and run `encrypt-existing` again - it only processes objects without encryption metadata, so it's safe to retry.
+If any objects failed, check the logs for details and re-POST to `/admin/api/encrypt-existing` again - it only processes objects without encryption metadata, so it's safe to retry.
 
 ## Important Notes
 

--- a/web/content/guides/key-rotation.md
+++ b/web/content/guides/key-rotation.md
@@ -52,13 +52,17 @@ After restarting, new objects use the new key. Existing objects can still be rea
 
 ## Step 4: Re-wrap All DEKs
 
-Run the admin command to re-wrap all DEKs with the new master key:
+Re-wrap all DEKs by hitting the admin API. The orchestrator does not ship a
+CLI subcommand for this — use the HTTP endpoint:
 
 ```bash
-s3-orchestrator admin rotate-encryption-key --old-key-id config-0
+curl -X POST http://orchestrator-host:9000/admin/api/rotate-encryption-key \
+  -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"old_key_id":"config-0"}'
 ```
 
-The `--old-key-id` identifies which key's DEKs to re-wrap:
+The `old_key_id` body field identifies which key's DEKs to re-wrap:
 
 | Key source | ID format |
 |-----------|-----------|

--- a/web/content/guides/minio-cloud-replication.md
+++ b/web/content/guides/minio-cloud-replication.md
@@ -10,7 +10,7 @@ This guide shows how to automatically replicate objects from a local MinIO insta
 
 MinIO is a popular self-hosted S3-compatible object store, but local storage carries risk - hardware failures, power loss, or site disasters can cause data loss. By placing S3 Orchestrator in front of your MinIO instance and adding a single cloud backend with a replication factor of 2, every object you write to MinIO is automatically copied to the cloud in the background.
 
-That is all it takes: one cloud backend and `replication_factor: 2`. The orchestrator's built-in replicator handles the rest. No cron jobs, rsync scripts, or third-party sync tools are needed.
+That is all it takes: one cloud backend and `replication.factor: 2`. The orchestrator's built-in replicator handles the rest. No cron jobs, rsync scripts, or third-party sync tools are needed.
 
 If the local MinIO goes down, reads automatically fail over to the cloud replica.
 
@@ -35,7 +35,7 @@ backends:
     bucket: data
     access_key_id: "${MINIO_ACCESS_KEY}"
     secret_access_key: "${MINIO_SECRET_KEY}"
-    quota: 0  # No quota - local storage is yours
+    quota_bytes: 0  # No quota - local storage is yours
 ```
 
 ## Step 2: Add a Cloud Backend
@@ -50,7 +50,7 @@ backends:
     bucket: data
     access_key_id: "${MINIO_ACCESS_KEY}"
     secret_access_key: "${MINIO_SECRET_KEY}"
-    quota: 0
+    quota_bytes: 0
 
   - name: r2
     endpoint: https://<account-id>.r2.cloudflarestorage.com
@@ -58,7 +58,7 @@ backends:
     bucket: minio-backup
     access_key_id: "${R2_ACCESS_KEY}"
     secret_access_key: "${R2_SECRET_KEY}"
-    quota: 10737418240  # 10 GB
+    quota_bytes: 10737418240  # 10 GB
 ```
 
 ## Step 3: Enable Replication
@@ -66,7 +66,8 @@ backends:
 Set the replication factor to 2. This tells the orchestrator that every object must exist on **two** backends - your local MinIO and the cloud backend.
 
 ```yaml
-replication_factor: 2
+replication:
+  factor: 2
 ```
 
 That is the entire replication setup. The orchestrator writes objects to MinIO on upload, and the background replicator automatically copies each one to R2. No manual sync step, no scheduled jobs.
@@ -156,10 +157,12 @@ Generate a key with `openssl rand -base64 32` and store it securely.
 
 After restarting the orchestrator, all new writes are encrypted automatically. Both the primary copy on MinIO and the replica on the cloud backend are encrypted — backends never see plaintext.
 
-To encrypt objects that were uploaded before encryption was enabled, run:
+To encrypt objects that were uploaded before encryption was enabled, hit the admin API:
 
 ```bash
-s3-orchestrator admin encrypt-existing
+curl -X POST http://orchestrator-host:9000/admin/api/encrypt-existing \
+  -H "Authorization: Bearer ${ADMIN_TOKEN}"
+# {"status":"complete","encrypted":N,"failed":N,"total":N}
 ```
 
 For production deployments, consider using [Vault Transit](../nomad-vault-deployment/) instead of an inline key. See the [Encrypting Existing Data](../encrypting-existing-data/) guide for the full walkthrough and the [Key Rotation](../key-rotation/) guide for rotating master keys.

--- a/web/content/guides/multi-cloud-redundancy.md
+++ b/web/content/guides/multi-cloud-redundancy.md
@@ -30,25 +30,25 @@ backends:
     endpoint: https://objectstorage.us-ashburn-1.oraclecloud.com
     region: us-ashburn-1
     bucket: primary-bucket
-    access_key: "<oci-access-key>"
-    secret_key: "<oci-secret-key>"
-    quota: 10737418240  # 10 GB
+    access_key_id: "<oci-access-key>"
+    secret_access_key: "<oci-secret-key>"
+    quota_bytes: 10737418240  # 10 GB
 
   - name: r2
     endpoint: https://<account-id>.r2.cloudflarestorage.com
     region: auto
     bucket: primary-bucket
-    access_key: "<r2-access-key>"
-    secret_key: "<r2-secret-key>"
-    quota: 10737418240  # 10 GB
+    access_key_id: "<r2-access-key>"
+    secret_access_key: "<r2-secret-key>"
+    quota_bytes: 10737418240  # 10 GB
 
   - name: b2
     endpoint: https://s3.us-west-004.backblazeb2.com
     region: us-west-004
     bucket: primary-bucket
-    access_key: "<b2-access-key>"
-    secret_key: "<b2-secret-key>"
-    quota: 10737418240  # 10 GB
+    access_key_id: "<b2-access-key>"
+    secret_access_key: "<b2-secret-key>"
+    quota_bytes: 10737418240  # 10 GB
 ```
 
 The `spread` strategy distributes writes evenly across backends, keeping storage usage balanced.
@@ -58,7 +58,8 @@ The `spread` strategy distributes writes evenly across backends, keeping storage
 The replication factor controls how many copies of each object exist across your backends. Set it to the number of independent copies you want.
 
 ```yaml
-replication_factor: 2
+replication:
+  factor: 2
 ```
 
 With three backends and a replication factor of 2, each object is written to one backend on upload and then asynchronously copied to one additional backend. A factor of 3 would place a copy on every backend.
@@ -74,8 +75,9 @@ Create a virtual bucket with credentials for your application.
 ```yaml
 buckets:
   - name: myapp
-    access_key: "<client-access-key>"
-    secret_key: "<client-secret-key>"
+    credentials:
+      - access_key_id: "<client-access-key>"
+        secret_access_key: "<client-secret-key>"
 ```
 
 ## Step 4: Connect Your Application
@@ -84,7 +86,7 @@ Point your application at the orchestrator endpoint using the virtual bucket cre
 
 ```bash
 # AWS CLI
-aws configure set default.endpoint_url http://orchestrator-host:8080
+aws configure set default.endpoint_url http://orchestrator-host:9000
 aws s3 cp report.pdf s3://myapp/report.pdf
 
 # rclone
@@ -93,7 +95,7 @@ rclone copy report.pdf s3orchestrator:myapp/
 # Python (boto3)
 import boto3
 s3 = boto3.client('s3',
-    endpoint_url='http://orchestrator-host:8080',
+    endpoint_url='http://orchestrator-host:9000',
     aws_access_key_id='<client-access-key>',
     aws_secret_access_key='<client-secret-key>')
 s3.upload_file('report.pdf', 'myapp', 'report.pdf')


### PR DESCRIPTION
Closes #878.

Single PR landing the full punch list from the 8-agent documentation audit. **No code changes** — 15 docs + the Grafana dashboard JSON.

## Summary by area

### P0 — examples that would not work as written
- `web/content/guides/multi-cloud-redundancy.md`, `minio-cloud-replication.md`: fixed wrong YAML field names (`access_key`/`secret_key` → `access_key_id`/`secret_access_key`, `quota` → `quota_bytes`, `replication_factor:` → `replication.factor:`, port 8080 → 9000, bucket credentials wrapped in `credentials:` block).
- `web/content/guides/key-rotation.md`, `encrypting-existing-data.md`, `minio-cloud-replication.md`: replaced three non-existent CLI subcommands with the actual HTTP admin endpoints + working curl invocations.
- `docs/performance-tuning.md`: removed bogus `pgx_pool_*` Prometheus references (no such metrics); fixed `usage_flush.adaptive_enabled` example to reflect the actual default (`false`).
- `docs/benchmarking.md`: replaced stale bench-file paths with the real list (under `internal/proxy/object/`, `internal/counter/`, etc).

### Missing metrics & API surface in README and admin-guide
- `README.md`: added 5 missing Prometheus rows (`s3o_pending_intents_*`, `s3o_drain_race_aborted_total`, `s3o_cleanup_queue_stale_claims_recovered_total`), refreshed `s3o_drain_active` description for the Inc/Dec semantics post-#653, added `success_absent` label to `s3o_cleanup_queue_processed_total`, added missing `/admin/api/reload-status` and `/admin/api/workers` to the API table.
- `docs/admin-guide.md`: same metric additions, plus 8 missing audit events (`cleanup_queue.already_absent`, `pending_reaper.*`, `over_replication.*`, `storage.OrphanEnqueueFailed`, `storage.UploadPart`), added the missing `multipart_stale_timeout` config key.
- Fixed the `/health` and `/health/ready` response-shape claims (the previously-documented `instance` field does not exist).

### admin-guide new sections (~311 lines added)
- `### write_path` — full coverage of the `pending_pattern` config block, the PUT-before-COMMIT pattern, the PendingReaper's HEAD-based resolution flow, and the relevant metrics + audit events.
- `## Admin API Reference` — per-endpoint docs for all 24 `/admin/api/*` endpoints (HTTP method/path, request payload, response shape, errors, example curl), grouped into Health & Status, Object inspection, Cleanup & quota, Replication, Drain & backend lifecycle, Encryption operations, Integrity, Reconciliation, Cache management.

### Diagrams
- `write-path.md`: added the `InsertPendingIntent` step before the backend PUT and the post-PUT `IsDraining` re-check / drain-race abort branch; added tooltips for `INTENT`, `DRAINRACE`, `DRAINABORT`; added a "Pending-Intent Pattern" prose section.
- `background-services.md`, `architecture.md`: added the PendingReaper worker with edges, tooltips, and a Service Summary row.
- `database-schema.md`: added the `pending_objects` table to the ER diagram with full column list, FK relationship, interactivity registration, nodeInfo block, and Table Summary row.

### Release notes
- `docs/version-migration.md`: corrected the "(current)" marker (was v0.47.x, actual v0.57.1) and backfilled behaviour-changing release notes for v0.47.5 (#824), v0.49.x (#847), v0.52.x (#866 + #867), v0.53.x (#868), v0.54.x (#869), v0.56.x (#874), v0.57.0 (#876), v0.57.1 (#877). Behaviour-neutral refactors (proxy decomposition, infra.Core split, notifier-mock thread-safety, test parallelization) are intentionally elided.

### Grafana coverage backfill (added during PR per scope expansion)
- `grafana/s3-orchestrator.json`: added 4 new rows (Worker Health, Event Notifications, Cleanup DLQ & Enqueue Failures, Coverage Backfill) covering 22 previously-orphan metrics. After this patch every declared `s3o_*` metric (excluding histogram base names queried via `_bucket`) has at least one panel.

### Out of scope
- `web/content/godoc/*` (auto-generated by gomarkdoc on each build).
- Behaviour-neutral release notes for the refactor train — covered in `docs/style-guide.md`.

## Test plan
- [x] `go build ./...` green (no code changes; sanity check)
- [x] `jq empty grafana/s3-orchestrator.json` — dashboard JSON valid
- [x] `jq '.panels | length' grafana/s3-orchestrator.json` — 89 → 112 panels
- [x] `grep -oE 's3o_[a-z_]+' grafana/s3-orchestrator.json | sort -u` matches every declared metric (excluding histogram base names)
- [x] No stale CLI references remain (`grep -E "s3-orchestrator admin (encrypt-existing|rotate-encryption-key)" web/content/guides/` returns empty)
- [x] No bogus `pgx_pool_*` references (`grep "pgx_pool" docs/` returns empty)
- [x] Stale bench-file paths gone (`grep "internal/proxy/location_cache_bench_test.go" docs/` returns empty)
- [ ] Render `hugo` locally to confirm the mermaid diagrams still build (requires `make web-build`; not run here)