### PR TITLE
GH_ISSUE_889: Helm chart support for dedicated metrics listener + opt-in pprof

### DIFF
--- a/deploy/helm/s3-orchestrator/Chart.yaml
+++ b/deploy/helm/s3-orchestrator/Chart.yaml
@@ -14,8 +14,8 @@ apiVersion: v2
 name: s3-orchestrator
 description: Unified S3-compatible storage across multiple backends
 type: application
-version: 0.1.0
-appVersion: "v0.20.0"
+version: 0.2.0
+appVersion: "v0.58.1"
 home: https://s3-orchestrator.munchbox.cc
 sources:
   - https://github.com/afreidah/s3-orchestrator

--- a/deploy/helm/s3-orchestrator/templates/configmap.yaml
+++ b/deploy/helm/s3-orchestrator/templates/configmap.yaml
@@ -7,8 +7,24 @@
 # tweak per-environment settings (backends, buckets, server listener) via
 # values without rebuilding the image. Mounted into the Deployment at
 # /etc/s3-orchestrator/config.yaml.
+#
+# When .Values.metrics.dedicatedListener.enabled is true, the rendered config
+# overrides config.telemetry.metrics.{listen,pprof} so operators set a single
+# source of truth at the chart level instead of duplicating port numbers
+# between the k8s plumbing (Service/Deployment/NetworkPolicy) and the runtime
+# config.
 # -------------------------------------------------------------------------------
 
+{{- $config := deepCopy .Values.config -}}
+{{- if .Values.metrics.dedicatedListener.enabled -}}
+  {{- $_ := set $config "telemetry" (default (dict) $config.telemetry) -}}
+  {{- $_ = set $config.telemetry "metrics" (default (dict) $config.telemetry.metrics) -}}
+  {{- $port := int .Values.metrics.dedicatedListener.port -}}
+  {{- $_ = set $config.telemetry.metrics "listen" (printf "0.0.0.0:%d" $port) -}}
+  {{- if .Values.metrics.pprof -}}
+    {{- $_ = set $config.telemetry.metrics "pprof" true -}}
+  {{- end -}}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -17,4 +33,4 @@ metadata:
     {{- include "s3-orchestrator.labels" . | nindent 4 }}
 data:
   config.yaml: |
-    {{- toYaml .Values.config | nindent 4 }}
+    {{- toYaml $config | nindent 4 }}

--- a/deploy/helm/s3-orchestrator/templates/deployment.yaml
+++ b/deploy/helm/s3-orchestrator/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.metrics.enabled }}
         prometheus.io/scrape: "true"
-        prometheus.io/port: {{ .Values.service.port | quote }}
+        prometheus.io/port: {{ if .Values.metrics.dedicatedListener.enabled }}{{ .Values.metrics.dedicatedListener.port | quote }}{{ else }}{{ .Values.service.port | quote }}{{ end }}
         prometheus.io/path: {{ .Values.metrics.path | quote }}
         {{- end }}
     spec:
@@ -57,6 +57,11 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+            {{- if .Values.metrics.dedicatedListener.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.metrics.dedicatedListener.port }}
+              protocol: TCP
+            {{- end }}
           env:
             {{- range $key, $value := .Values.env }}
             - name: {{ $key }}

--- a/deploy/helm/s3-orchestrator/templates/networkpolicy.yaml
+++ b/deploy/helm/s3-orchestrator/templates/networkpolicy.yaml
@@ -6,6 +6,11 @@
 # Optional NetworkPolicy that pins ingress to the configured podSelectors and
 # egress to the upstream backend CIDRs. Gated by .Values.networkPolicy.enabled
 # so clusters without a CNI that enforces NetworkPolicies can leave it off.
+#
+# When .Values.metrics.dedicatedListener.enabled is true, a second ingress
+# rule allows the configured scraperSelector (defaulting to "any pod in the
+# namespace") to reach the metrics port. Pprof rides on the same port, so
+# tightening scraperSelector matters more when .Values.metrics.pprof is on.
 # -------------------------------------------------------------------------------
 
 {{- if .Values.networkPolicy.enabled }}
@@ -24,6 +29,18 @@ spec:
     - ports:
         - port: {{ .Values.service.port }}
           protocol: TCP
+    {{- if .Values.metrics.dedicatedListener.enabled }}
+    - from:
+        {{- if .Values.metrics.dedicatedListener.scraperSelector }}
+        - podSelector:
+            {{- toYaml .Values.metrics.dedicatedListener.scraperSelector | nindent 12 }}
+        {{- else }}
+        - podSelector: {}
+        {{- end }}
+      ports:
+        - port: {{ .Values.metrics.dedicatedListener.port }}
+          protocol: TCP
+    {{- end }}
   egress:
     - {}
 {{- end }}

--- a/deploy/helm/s3-orchestrator/templates/service.yaml
+++ b/deploy/helm/s3-orchestrator/templates/service.yaml
@@ -6,6 +6,14 @@
 # ClusterIP Service that routes S3 traffic to the orchestrator pods.
 # Service type, port, and target port come from .Values so operators
 # can switch to LoadBalancer or NodePort without templating.
+#
+# When .Values.metrics.dedicatedListener.enabled is true, a second
+# *-metrics ClusterIP Service is rendered alongside. Keeping it
+# separate (instead of adding a port to the public Service) lets the
+# NetworkPolicy and any ServiceMonitor target the metrics surface
+# without touching the S3 ingress path, and prevents the metrics
+# port from accidentally being exposed when the public Service is
+# upgraded to LoadBalancer/NodePort.
 # -------------------------------------------------------------------------------
 
 apiVersion: v1
@@ -23,3 +31,24 @@ spec:
       port: {{ .Values.service.port }}
       targetPort: http
       protocol: TCP
+{{- if .Values.metrics.dedicatedListener.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "s3-orchestrator.fullname" . }}-metrics
+  labels:
+    {{- include "s3-orchestrator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: metrics
+spec:
+  # Always ClusterIP regardless of .Values.service.type - the metrics
+  # surface (especially with pprof) must never be exposed externally.
+  type: ClusterIP
+  selector:
+    {{- include "s3-orchestrator.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: metrics
+      port: {{ .Values.metrics.dedicatedListener.port }}
+      targetPort: metrics
+      protocol: TCP
+{{- end }}

--- a/deploy/helm/s3-orchestrator/values.yaml
+++ b/deploy/helm/s3-orchestrator/values.yaml
@@ -62,6 +62,38 @@ metrics:
   enabled: true
   path: /metrics
 
+  # Dedicated metrics listener (parity with the Nomad deployment).
+  # When enabled, the orchestrator binds /metrics to a separate port
+  # instead of multiplexing on the main S3 listener. The chart creates
+  # a containerPort, a *-metrics ClusterIP Service, and (when the top-
+  # level networkPolicy is enabled) an ingress rule scoped to the
+  # configured scraper selector.
+  #
+  # Leave disabled for the simplest deployment shape (inline metrics
+  # on the S3 port, no pprof, no extra Service).
+  dedicatedListener:
+    enabled: false
+    port: 9001
+    # podSelector for the NetworkPolicy ingress rule. Defaults to "any
+    # pod in the namespace"; tighten this to your Prometheus operator
+    # pods to keep the metrics surface internal.
+    scraperSelector: {}
+    # Example:
+    # scraperSelector:
+    #   matchLabels:
+    #     app.kubernetes.io/name: prometheus
+
+  # Pprof endpoints (/debug/pprof/*) are mounted on the dedicated
+  # metrics listener when this is true. OFF by default - pprof exposes
+  # runtime internals (stack frames, command-line flags, on-demand CPU
+  # profiles that double as DoS amplifiers). Only opt in temporarily
+  # for active profiling investigations and keep the metrics Service
+  # selector pinned to cluster-internal scrapers.
+  #
+  # Has no effect unless metrics.dedicatedListener.enabled is also true
+  # (inline metrics never get pprof).
+  pprof: false
+
 # Use an existing Secret instead of creating one from .secrets below.
 # The Secret must contain all env vars referenced by ${VAR} in the config.
 existingSecret: ""

--- a/deploy/kubernetes/local/values.yaml
+++ b/deploy/kubernetes/local/values.yaml
@@ -27,6 +27,18 @@ resources:
 networkPolicy:
   enabled: false
 
+# Mirror the Nomad demo: expose /metrics and pprof on a dedicated
+# listener so perf runs against the local k3d cluster can capture
+# heap/cpu/alloc profiles via /debug/pprof/*. Production should leave
+# both flags off (chart defaults).
+metrics:
+  enabled: true
+  path: /metrics
+  dedicatedListener:
+    enabled: true
+    port: 9001
+  pprof: true
+
 ingress:
   enabled: false
 

--- a/docs/security-hardening.md
+++ b/docs/security-hardening.md
@@ -246,9 +246,12 @@ Provide the environment variables via systemd `EnvironmentFile`, Vault agent inj
     metrics:
       enabled: true
       listen: "127.0.0.1:9091"  # only reachable from localhost / internal network
+      pprof: false              # opt-in; see "Pprof endpoints" below
   ```
 
   When `listen` is set, `/metrics` is not served on the main S3 port. Prometheus scrapes from the internal address instead.
+
+- **Pprof endpoints** (`/debug/pprof/*`) expose deep runtime state — stack frames, command-line flags, on-demand CPU profiles that double as DoS amplifiers (`/debug/pprof/profile?seconds=300`). They are **off by default** and only mounted when both `telemetry.metrics.listen` is set AND `telemetry.metrics.pprof: true`. Inline-metrics deployments (no dedicated listener) never get pprof regardless of the flag. Enable temporarily for profiling investigations only, and keep the metrics listener bound to an internal-only interface.
 
 ### Kubernetes Hardening
 
@@ -256,7 +259,8 @@ The provided Kubernetes manifests include several security measures:
 
 - **seccompProfile: RuntimeDefault** — applies the default seccomp profile to restrict syscalls
 - **automountServiceAccountToken: false** — the orchestrator does not need Kubernetes API access
-- **NetworkPolicy** — restricts ingress to port 9000 only; egress is permissive since backend endpoints are config-driven
+- **NetworkPolicy** — restricts ingress to port 9000 (and the metrics port when `metrics.dedicatedListener.enabled` is set, scoped to the configured `scraperSelector`); egress is permissive since backend endpoints are config-driven
+- **Dedicated metrics Service** — when `metrics.dedicatedListener.enabled: true`, the chart renders a separate `*-metrics` ClusterIP Service that is forced to `ClusterIP` regardless of the public Service type. This prevents the metrics surface (and any opted-in pprof) from accidentally being exposed externally if the public Service is upgraded to LoadBalancer/NodePort.
 - **readOnlyRootFilesystem**, **runAsNonRoot**, **capabilities.drop: ALL** — standard container hardening (see `deploy/helm/s3-orchestrator/templates/deployment.yaml`)
 
 ```


### PR DESCRIPTION
## Summary
- Helm chart parity with the Nomad deployment shipped in #886/#887: operators on k8s can now bind \`/metrics\` (and optionally \`/debug/pprof/*\`) to a dedicated port on a separate ClusterIP Service instead of multiplexing on the public S3 listener.
- Single source of truth at the chart level: \`metrics.dedicatedListener.{enabled,port}\` and \`metrics.pprof\` drive both the k8s primitives (containerPort, Service, NetworkPolicy ingress, prometheus.io scrape port) AND the rendered runtime \`config.telemetry.metrics.{listen,pprof}\` overrides in the ConfigMap.
- Defaults unchanged; existing installs render identically.

## What's new in values.yaml
\`\`\`yaml
metrics:
  enabled: true
  path: /metrics
  dedicatedListener:
    enabled: false        # opt-in
    port: 9001
    scraperSelector: {}   # narrow to Prometheus pods for tighter NetworkPolicy
  pprof: false            # no-op unless dedicatedListener.enabled
\`\`\`

When \`dedicatedListener.enabled=true\` the chart renders:
- A second Service \`*-metrics\` (forced \`ClusterIP\` regardless of the public Service type — pprof can never leak through a LoadBalancer/NodePort upgrade).
- A second containerPort on the Deployment.
- A second NetworkPolicy ingress rule scoped to \`scraperSelector\` (defaults to any pod in the namespace).
- \`prometheus.io/port\` annotation pointing at the metrics port.
- \`config.telemetry.metrics.listen: \"0.0.0.0:9001\"\` and (when \`pprof: true\`) \`pprof: true\` rendered into the ConfigMap.

\`deploy/kubernetes/local/values.yaml\` flips both on so the local k3d demo mirrors the Nomad local demo (perf runs can scrape pprof).

## Test plan
- [x] \`helm lint deploy/helm/s3-orchestrator/\` — clean
- [x] \`helm lint deploy/helm/s3-orchestrator/ -f deploy/kubernetes/local/values.yaml\` — clean
- [x] \`helm template\` with defaults: one Service, one containerPort, prom scrape on 9000, no pprof in ConfigMap, no NetworkPolicy ingress for metrics port (smoke-tested locally).
- [x] \`helm template\` with \`metrics.dedicatedListener.enabled=true metrics.pprof=true\`: two Services (public + \`-metrics\`), two containerPorts, prom scrape on 9001, \`listen: 0.0.0.0:9001\` + \`pprof: true\` in ConfigMap, NetworkPolicy ingress rule on metrics port.
- [x] \`helm template\` with explicit \`scraperSelector.matchLabels.app.kubernetes.io/name=prometheus\`: NetworkPolicy ingress \`from.podSelector\` is correctly scoped.

## Bumps
- Chart \`version\`: \`0.1.0\` -> \`0.2.0\` (new feature in chart).
- Chart \`appVersion\`: \`v0.20.0\` -> \`v0.58.1\` (was wildly stale; sync to current binary).
- Binary \`.version\`: unchanged (no Go/SQL touched, per docs/style-guide.md versioning rule).

## Docs
\`docs/security-hardening.md\` updated with:
- The pprof opt-in posture (both \`listen\` set AND \`pprof: true\` required; inline metrics never get pprof).
- The dedicated-metrics-Service forced-ClusterIP guarantee.

Closes #889.