### PR TITLE
GH_ISSUE_833: align loadtest go.mod with root + CI drift check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,35 @@ jobs:
           fi
           echo "Version bumped: $BASE_VERSION → $PR_VERSION"
 
+  # Catches go.mod drift between root and nested modules. The vendored
+  # Hugo theme under web/themes/** is excluded - it is a third-party
+  # project synced from upstream and pins its own minimum Go version.
+  go-version-drift:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Verify nested go.mod files match root
+        run: |
+          ROOT=$(awk '$1=="go"{print $2; exit}' go.mod)
+          if [ -z "$ROOT" ]; then
+            echo "::error::failed to parse go directive from root go.mod"
+            exit 1
+          fi
+          echo "Root Go version: $ROOT"
+          status=0
+          while IFS= read -r mod; do
+            ver=$(awk '$1=="go"{print $2; exit}' "$mod")
+            if [ "$ver" != "$ROOT" ]; then
+              echo "::error file=$mod::go directive $ver does not match root $ROOT"
+              status=1
+            else
+              echo "ok: $mod -> $ver"
+            fi
+          done < <(find . -name go.mod -not -path './go.mod' -not -path './web/themes/*' -not -path './vendor/*')
+          exit $status
+
   lint:
     needs: [changes]
     if: needs.changes.outputs.go == 'true'

--- a/loadtest/go.mod
+++ b/loadtest/go.mod
@@ -1,6 +1,6 @@
 module github.com/afreidah/s3-orchestrator/loadtest
 
-go 1.26.1
+go 1.26.3
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.3

--- a/web/content/godoc/config.md
+++ b/web/content/godoc/config.md
@@ -496,15 +496,18 @@ type LifecycleRule struct {
 ```
 
 <a name="MetricsConfig"></a>
-## type [MetricsConfig](<https://github.com/afreidah/s3-orchestrator/blob/main/internal/config/telemetry.go#L22-L26>)
+## type [MetricsConfig](<https://github.com/afreidah/s3-orchestrator/blob/main/internal/config/telemetry.go#L29-L34>)
 
 MetricsConfig holds Prometheus metrics settings.
+
+Pprof is opt\-in and off by default. The net/http/pprof handlers expose deep runtime state \(de\-anonymized stack frames, command\-line flags, on\-demand CPU profiles that double as DoS amplifiers\), so production deployments should leave Pprof false. When enabled, it is only mounted on the dedicated metrics listener \(Listen must be set\) \- never on the main S3 listener.
 
 ```go
 type MetricsConfig struct {
     Enabled bool   `yaml:"enabled"`
     Path    string `yaml:"path"`
     Listen  string `yaml:"listen"` // Separate listener address (e.g. "127.0.0.1:9091"); if empty, metrics are served on the main listener
+    Pprof   bool   `yaml:"pprof"`  // Mount /debug/pprof/* on the metrics listener. Off by default; requires Listen to be set.
 }
 ```
 
@@ -707,7 +710,7 @@ type TelemetryConfig struct {
 ```
 
 <a name="TracingConfig"></a>
-## type [TracingConfig](<https://github.com/afreidah/s3-orchestrator/blob/main/internal/config/telemetry.go#L29-L34>)
+## type [TracingConfig](<https://github.com/afreidah/s3-orchestrator/blob/main/internal/config/telemetry.go#L37-L42>)
 
 TracingConfig holds OpenTelemetry tracing settings.
 

--- a/web/content/godoc/telemetry.md
+++ b/web/content/godoc/telemetry.md
@@ -374,11 +374,28 @@ var (
         },
     )
 
-    // DrainActive is 1 when a drain operation is in progress, 0 otherwise.
+    // DrainActive is the live count of in-flight drain operations.
+    // Inc'd on StartDrain and Dec'd on completion (success, cancel, or
+    // abort) so concurrent drains across different backends do not
+    // clobber each other's state the way a Set(0)/Set(1) gauge would.
+    // 0 means no drains are running.
     DrainActive = promauto.NewGauge(
         prometheus.GaugeOpts{
             Name: "s3o_drain_active",
-            Help: "Whether a backend drain operation is currently in progress",
+            Help: "Count of in-flight backend drain operations (Inc/Dec so concurrent drains compose)",
+        },
+    )
+
+    // DrainRaceAbortedTotal counts PutObject attempts that landed bytes
+    // on a backend whose drain started mid-write. The orchestrator
+    // detects the race after the backend PUT completes, deletes the
+    // orphaned bytes, and fails the attempt over to the next eligible
+    // backend; this counter pins how often the race fires in production
+    // so the drain timing assumptions can be revisited if it climbs.
+    DrainRaceAbortedTotal = promauto.NewCounter(
+        prometheus.CounterOpts{
+            Name: "s3o_drain_race_aborted_total",
+            Help: "Number of PutObject attempts aborted after drain started mid-write",
         },
     )
 )
@@ -1014,6 +1031,7 @@ var (
     AttrDegradedMode      = attribute.Key("s3o.degraded_mode")
     AttrCacheHit          = attribute.Key("s3o.cache_hit")
     AttrParallelBroadcast = attribute.Key("s3o.parallel_broadcast")
+    AttrNativeCopy        = attribute.Key("s3o.native_copy")
 )
 ```
 
@@ -1064,7 +1082,7 @@ var Version = "dev"
 ```
 
 <a name="BackendAttributes"></a>
-## func [BackendAttributes](<https://github.com/afreidah/s3-orchestrator/blob/main/internal/observe/telemetry/tracing.go#L169>)
+## func [BackendAttributes](<https://github.com/afreidah/s3-orchestrator/blob/main/internal/observe/telemetry/tracing.go#L170>)
 
 ```go
 func BackendAttributes(operation, backendName, endpoint, bucket, key string) []attribute.KeyValue
@@ -1093,7 +1111,7 @@ NewCircuitBreakerHook returns the callback to install on a breaker so its state 
 Initializes the gauge to "closed" up front so Prometheus reports a value before the first transition.
 
 <a name="RequestAttributes"></a>
-## func [RequestAttributes](<https://github.com/afreidah/s3-orchestrator/blob/main/internal/observe/telemetry/tracing.go#L158>)
+## func [RequestAttributes](<https://github.com/afreidah/s3-orchestrator/blob/main/internal/observe/telemetry/tracing.go#L159>)
 
 ```go
 func RequestAttributes(method, path, bucket, key, clientIP string) []attribute.KeyValue


### PR DESCRIPTION
## Summary
- Bumps \`loadtest/go.mod\` from \`go 1.26.1\` to \`go 1.26.3\` to match root.
- Adds a \`go-version-drift\` CI job that fails the build if any nested go.mod diverges from root. Exempts \`web/themes/**\` (vendored Hugo theme — re-synced from upstream, pins its own minimum).
- No source files change; CI version-check regex doesn't match, so \`.version\` stays at v0.58.2.

## Test plan
- [x] \`cd loadtest && go build -buildvcs=false ./...\` — builds at 1.26.3
- [x] Drift script dry-run locally — \`ok: ./loadtest/go.mod -> 1.26.3\`, exit 0
- [x] No \`.go\`/\`.sql\` files touched, so the existing version-check job won't fire (no bump required per its regex)

Closes #833.