### PR TITLE
chore(ci): refresh webpage Trivy scan against current Alpine base

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,8 +364,8 @@ jobs:
           tags: |
             ghcr.io/afreidah/s3-orchestrator-webpage:${{ steps.version.outputs.version }}
             ghcr.io/afreidah/s3-orchestrator-webpage:latest
-          cache-from: type=gha,scope=webpage-v2
-          cache-to: type=gha,mode=max,scope=webpage-v2
+          cache-from: type=gha,scope=webpage-v3
+          cache-to: type=gha,mode=max,scope=webpage-v3
 
       - name: Sign image with cosign
         env:


### PR DESCRIPTION
## What

Bump the `docker-webpage` build cache scope `webpage-v2` → `webpage-v3`.

## Why

Post-merge of #1010, the `docker-webpage` Trivy scan went red on `main`:

```
ghcr.io/afreidah/s3-orchestrator-webpage:v0.60.41 (alpine 3.23.4)
Total: 1 (HIGH: 1, CRITICAL: 0)
libxml2  CVE-2026-6732  HIGH  fixed  2.13.9-r0 -> 2.13.9-r1
```

The final stage already runs `RUN apk upgrade --no-cache`, but the gha layer
cache (`scope=webpage-v2`) held a **stale** copy of that layer from before
`libxml2 2.13.9-r1` was published — so the image kept shipping the vulnerable
`-r0`. `pull: true` only refreshes the `nginx:alpine` base, not the cached
upgrade layer on top.

Bumping the cache scope busts the stale layer so `apk upgrade` re-runs against
the current Alpine package index and picks up the fix. This is the same class
of refresh as 6ac3069, done via the cache key instead of an empty re-trigger
commit.

## Note

This is the quick fix and will recur whenever a new Alpine CVE lands and the
cache goes stale again. A durable follow-up (a per-build cache-bust `ARG` on the
upgrade layer) is tracked separately if we want to end the treadmill.