### PR TITLE
fix(ci): treat cosign Rekor 409 as already-signed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,7 +383,18 @@ jobs:
       - name: Sign image with cosign
         env:
           DIGEST: ${{ steps.push.outputs.digest }}
-        run: cosign sign --yes ghcr.io/afreidah/s3-orchestrator-webpage@${DIGEST}
+        # A Rekor 409 means the signature is already in the transparency log
+        # (slow public instance + client retry), so treat that one case as success.
+        run: |
+          set +e
+          out=$(cosign sign --yes ghcr.io/afreidah/s3-orchestrator-webpage@${DIGEST} 2>&1)
+          rc=$?
+          echo "$out"
+          if [ $rc -ne 0 ] && echo "$out" | grep -q "already exists in the transparency log"; then
+            echo "::warning::Rekor entry already present; treating as signed."
+            exit 0
+          fi
+          exit $rc
 
       - name: Scan image with Trivy
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,7 +312,18 @@ jobs:
       - name: Sign image with cosign
         env:
           DIGEST: ${{ steps.push.outputs.digest }}
-        run: cosign sign --yes ghcr.io/afreidah/s3-orchestrator@${DIGEST}
+        # A Rekor 409 means the signature is already in the transparency log
+        # (slow public instance + client retry), so treat that one case as success.
+        run: |
+          set +e
+          out=$(cosign sign --yes ghcr.io/afreidah/s3-orchestrator@${DIGEST} 2>&1)
+          rc=$?
+          echo "$out"
+          if [ $rc -ne 0 ] && echo "$out" | grep -q "already exists in the transparency log"; then
+            echo "::warning::Rekor entry already present; treating as signed."
+            exit 0
+          fi
+          exit $rc
 
       - name: Scan image with Trivy
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0


### PR DESCRIPTION
## Problem

The post-merge `docker` job failed at **Sign image with cosign**:

```
[POST /api/v1/log/entries][409] createLogEntryConflict
"an equivalent entry already exists in the transparency log"
```

The failing digest was brand-new (not signed by any prior run), so cosign created the entry itself: the public Rekor instance was slow (~32s for the call), the client timed out and retried, and the retry collided with the entry the first upload had already persisted. Same class of transient public-infra flake as the SonarCloud CDN errors.

A 409 "already exists" means the signature **is** in the transparency log — i.e. the artifact is signed. A plain re-run would 409 again because the entry now genuinely exists, so the step needs to be idempotent.

## Fix

Treat the "already exists in the transparency log" case as success; every other signing error still fails the step. Retry actions were deliberately avoided — retrying is what triggers the conflict.
