### PR TITLE
fix(loadtest): pin k6 multipart creds so it ignores ambient AWS_* env

### DIFF
--- a/loadtest/run-suite.sh
+++ b/loadtest/run-suite.sh
@@ -120,8 +120,16 @@ run_scenario "list" "$BINARY" \
   -output-json "$RESULTS_DIR/list.json"
 
 if command -v k6 >/dev/null; then
+  # Pin the demo creds explicitly: multipart.js reads AWS_* from __ENV, so
+  # without these it would inherit whatever AWS_ACCESS_KEY_ID/SECRET are exported
+  # in the caller's shell and sign with the wrong key (-> 403). The Go scenarios
+  # don't hit this because they default creds via flags, not the environment.
+  # k6 --env wins over inherited OS env, so these override any ambient AWS_*.
   run_scenario "multipart" k6 run loadtest/k6/multipart.js \
     --env "S3_ENDPOINT=$ENDPOINT" --env "S3_BUCKET=$BUCKET" \
+    --env "AWS_ACCESS_KEY_ID=photoskey" \
+    --env "AWS_SECRET_ACCESS_KEY=photossecret" \
+    --env "AWS_REGION=us-east-1" \
     --env "CONCURRENCY=$MPU_CONCURRENCY" \
     --env "PART_COUNT=$MPU_PART_COUNT" \
     --env "PART_SIZE=$MPU_PART_SIZE"


### PR DESCRIPTION
## Problem

`make perf` intermittently failed the **multipart** scenario with 100% errors — every `CreateMultipartUpload` returned **403** (`s3.AuthFailure`), while put/get/mixed/list passed. Root cause (diagnosed against the live nomad-demo):

- `loadtest/k6/multipart.js` sources creds from `__ENV`: `AWS_ACCESS_KEY_ID || "photoskey"`, etc. — it reads the **ambient environment** first.
- `run-suite.sh` passed `S3_ENDPOINT`/`S3_BUCKET`/concurrency to k6 but **not** the creds.
- So if the caller's shell had `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` exported (real AWS creds, a profile, direnv, etc.), k6 signed the multipart create with **those** → wrong signature → 403.
- The Go scenarios were unaffected: `s3-loadtest` defaults creds via **flags** (`-access-key photoskey`), never the environment.

That's why it "suddenly" broke (AWS vars appeared in the shell) and why only the k6-signed scenario failed. Verified the server is correct: `aws s3api create-multipart-upload` against the demo (with demo creds) returns 200.

## Fix

Pass the demo creds explicitly to k6 (k6 `--env` overrides inherited OS env), matching the Go binary's flag defaults:

```
--env "AWS_ACCESS_KEY_ID=photoskey"
--env "AWS_SECRET_ACCESS_KEY=photossecret"
--env "AWS_REGION=us-east-1"
```

Now the multipart scenario uses the demo creds regardless of the caller's environment, so `make perf` no longer depends on a clean shell.

Loadtest-harness only — no product code, no Go/SQL change (no version bump per policy). `bash -n` clean.