### PR TITLE
fix(ui): clear SonarCloud dashboard reliability & maintainability issues

### DIFF
--- a/internal/transport/ui/static/style.css
+++ b/internal/transport/ui/static/style.css
@@ -676,7 +676,7 @@ dialog#sync-dialog select:focus {
   margin: 0;
   padding: 0.5rem 1rem 0.6rem 4.5rem;
   white-space: pre-wrap;
-  word-break: break-word;
+  overflow-wrap: break-word;
   background: #0f172a;
   color: #cbd5e1;
   font-size: 0.85em;

--- a/internal/transport/ui/templates/dashboard.html
+++ b/internal/transport/ui/templates/dashboard.html
@@ -184,8 +184,8 @@
       <button id="upload-btn" class="btn-upload">Upload</button>
       <span id="upload-status"></span>
     </div>
-    <input type="file" id="upload-files-input" multiple hidden>
-    <input type="file" id="upload-folder-input" webkitdirectory hidden>
+    <input type="file" id="upload-files-input" aria-label="Upload files" multiple hidden>
+    <input type="file" id="upload-folder-input" aria-label="Upload folder" webkitdirectory hidden>
     {{if .Data.TopLevelEntries.Entries}}
     <div class="object-tree" id="object-tree">
       {{range .Data.TopLevelEntries.Entries}}
@@ -282,7 +282,7 @@
     <h2>Logs
       <button id="logs-refresh" class="btn-action">Refresh</button>
       <label class="logs-auto-label"><input type="checkbox" id="logs-auto"> Auto</label>
-      <select id="logs-level" class="logs-level-select">
+      <select id="logs-level" class="logs-level-select" aria-label="Filter logs by level">
         <option value="">All</option>
         <option value="DEBUG">Debug</option>
         <option value="INFO" selected>Info</option>
@@ -290,7 +290,7 @@
         <option value="ERROR">Error</option>
       </select>
     </h2>
-    <input type="text" id="logs-search" class="logs-search" placeholder="Filter logs...">
+    <input type="text" id="logs-search" class="logs-search" aria-label="Filter logs" placeholder="Filter logs...">
     <div id="logs-container" class="logs-container">
       <div class="tree-loading">Loading&hellip;</div>
     </div>


### PR DESCRIPTION
Clears all 5 open SonarCloud issues on \`afreidah_s3-orchestrator\` (4 reliability bugs + 1 maintainability smell), all in the dashboard UI.

## Reliability — \`Web:InputWithoutLabelCheck\` (4)
Added \`aria-label\` so every form control is accessibly named:
- \`dashboard.html:187\` — hidden "Upload files" file input
- \`dashboard.html:188\` — hidden "Upload folder" file input
- \`dashboard.html:285\` — log-level \`<select>\`
- \`dashboard.html:293\` — log-search input

Used \`aria-label\` rather than visible \`<label>\`s because two inputs are programmatically-triggered hidden file pickers and the others are inline toolbar controls where a visible label would disrupt the header layout. \`aria-label\` satisfies the rule and is the correct accessibility treatment.

## Maintainability — \`css:S1874\` (1)
- \`style.css:679\` — replaced deprecated \`word-break: break-word\` with \`overflow-wrap: break-word\` (same effect, pairs with the existing \`white-space: pre-wrap\`).

## Verification
- \`go test ./internal/transport/ui/...\` passes
- No test asserts on the changed markup