### PR TITLE
worker: scope the artifact key to this project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -670,10 +670,13 @@ worker-deploy: ## Publish the edge proxy worker (requires wrangler login and sec
 # implicitly; Terraform cannot, because cloudflare_workers_script takes finished
 # script text. These targets produce that artifact and put it where Terraform
 # can read it back.
+# The key is scoped to this project, because the bucket it lands in is not: a
+# prefix like "cloudflare-worker" alone would collide with anything else that
+# ever publishes a worker there.
 WORKER_BUNDLE := $(WORKER_DIR)/dist/worker.js
-WORKER_KEY    := artifacts/cloudflare-worker/$(VERSION)/worker.js
+WORKER_KEY    := s3-orchestrator/cloudflare-worker/$(VERSION)/worker.js
 S3O_ENDPOINT  ?= http://s3-orchestrator.service.consul:9000
-S3O_BUCKET    ?= unified
+S3O_BUCKET    ?= artifacts
 
 worker-build: ## Bundle the edge proxy worker into a single ESM script
 	cd $(WORKER_DIR) && npm run build

--- a/deploy/cloudflare-worker/README.md
+++ b/deploy/cloudflare-worker/README.md
@@ -75,7 +75,7 @@ make worker-publish    # bundle, then upload it to an S3 bucket
 that same single-module bundle as a file instead, for deploying the worker
 through the Cloudflare API rather than wrangler -- the API takes finished script
 text, and Cloudflare runs JavaScript, not TypeScript. `worker-publish` uploads it
-under `artifacts/cloudflare-worker/<version>/worker.js`; override `S3O_ENDPOINT`
+under `s3-orchestrator/cloudflare-worker/<version>/worker.js`; override `S3O_ENDPOINT`
 and `S3O_BUCKET` to point somewhere else.
 
 The worker is the only TypeScript in an otherwise Go repository and carries its own npm toolchain here, so a contributor who never touches it never installs Node. CI runs the checks only when this directory changes, and SonarQube skips it under the existing `deploy/**` exclusion.


### PR DESCRIPTION
Follow-up to #1471.

The published key was `artifacts/cloudflare-worker/<version>/worker.js` in a bucket also named `artifacts`, which nested an `artifacts/` directory inside it. The prefix was also too generic -- that bucket is shared, so "cloudflare-worker" alone would collide with anything else that ever publishes a worker there.

Key is now `s3-orchestrator/cloudflare-worker/<version>/worker.js`, and the default bucket moves from `unified` to `artifacts` to match.

No version bump: Makefile and README only, no Go or SQL.