### PR TITLE
ci: build and push images from Forgejo on merge to main

### DIFF
--- a/.forgejo/workflows/images.yml
+++ b/.forgejo/workflows/images.yml
@@ -1,0 +1,45 @@
+# -------------------------------------------------------------------------------
+# Build and push the container images on every merge to main.
+#
+# Author: Alex Freidah
+#
+# This file runs only on a Forgejo instance -- GitHub ignores .forgejo/workflows.
+# Its presence is also what stops Forgejo from falling back to .github/workflows,
+# which targets GitHub-hosted runners and fails on a self-hosted one.
+#
+# Nothing here is scoped to changed paths. The repository reaches Forgejo through
+# a mirror whose pushes are force-updated and can batch several commits, so a
+# push event's own commit range does not reliably describe what changed. A filter
+# that silently skips a build is worse than always building.
+#
+# `make push` tags from .version, so a merge that does not bump it republishes
+# that tag from current main.
+# -------------------------------------------------------------------------------
+
+name: Images
+
+on:
+  push:
+    branches: [main]
+
+env:
+  # The Makefile defaults REGISTRY to a placeholder so a fork never publishes here.
+  DOCKER_REGISTRY: registry.munchbox.cc
+
+jobs:
+  images:
+    name: Build and push images
+    runs-on: build
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build and push
+        run: |
+          set -euo pipefail
+
+          # The build host carries no qemu handlers, so without this buildx
+          # reports amd64 only and the arm64 half of each image fails.
+          docker run --privileged --rm tonistiigi/binfmt --install all
+
+          make push
+          make web-push


### PR DESCRIPTION
Adds a `.forgejo/workflows/images.yml` that builds and pushes this repository's container images on every merge to main, on the self-hosted `build` runner.

Two things this fixes:

1. There was no image build on the Forgejo side at all, so pushing a new image was a manual `make push` from a workstation.
2. With no `.forgejo/workflows` directory, Forgejo falls back to `.github/workflows`. Those target GitHub-hosted runners and have been failing on every mirrored commit for months. This file stops that fallback.

The build is not scoped to changed paths. The repo reaches Forgejo through a mirror whose pushes are force-updated and can batch several commits, so the push event's own commit range does not reliably describe what changed -- a filter that silently skips a build is worse than always building.

Needs the matching `runners/config` entry in munchbox, or the job queues with no runner.